### PR TITLE
Added model_selection import & simpler calculation of p_perm_k_norm in zscore model

### DIFF
--- a/ZscoreSustain.py
+++ b/ZscoreSustain.py
@@ -228,7 +228,7 @@ class ZscoreSustain(AbstractSustain):
             p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S_opt[s])
 
         p_perm_k_weighted                   = p_perm_k * f_val_mat
-        p_perm_k_norm                       = p_perm_k_weighted / np.tile(np.sum(np.sum(p_perm_k_weighted, 1), 1).reshape(M, 1, 1), (1, N + 1, N_S))  # the second summation axis is different to Matlab version
+        p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted, axis=(1,2), keepdims=True)
         f_opt                               = (np.squeeze(sum(sum(p_perm_k_norm))) / sum(sum(sum(p_perm_k_norm)))).reshape(N_S, 1, 1)
         f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
         f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))

--- a/simrun.py
+++ b/simrun.py
@@ -18,7 +18,7 @@ warnings.filterwarnings("ignore",category=cbook.mplDeprecation)
 from ZscoreSustain  import ZscoreSustain
 from MixtureSustain import MixtureSustain
 
-import sklearn
+import sklearn.model_selection
 
 def main():
     # cross-validation


### PR DESCRIPTION
Hello,

This is a minor fix. I added the import of sklearn.model_selection in simrun.py file as in line 131 in the same file, it was called without import. This was causing an error.
Also, I added a simpler calculation of p_perm_k_norm.

Regards,
Ahmed