### PR TITLE
PVD Plotting Update

### DIFF
--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -230,8 +230,11 @@ class AbstractSustain(ABC):
                     save_path=Path(self.output_folder) / f"{self.dataset_name}_subtype{s}_PVD.{plot_format}",
                     **kwargs
                 )
-                for fig in figs:
-                    fig.show()
+                if isinstance(figs, list):
+                    for fig in figs:
+                        fig.show()
+                else:
+                    figs.show()
 
                 ax0.plot(range(self.N_iterations_MCMC), samples_likelihood, label="Subtype " + str(s+1))
 

--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -401,7 +401,6 @@ class AbstractSustain(ABC):
         # Combine MCMC sequences across cross-validation folds to get cross-validated positional variance diagrams,
         # so that you get more realistic estimates of variance within event positions within subtypes
 
-
         pickle_dir                          = os.path.join(self.output_folder, 'pickle_files')
 
         #*********** load ML sequence for full model for N_subtypes
@@ -487,9 +486,14 @@ class AbstractSustain(ABC):
         # order of biomarkers in each subtypes' positional variance diagram
         plot_biomarker_order                = ml_sequence_EM_full[plot_subtype_order[0], :].astype(int)
 
-        fig, ax                             = self._plot_sustain_model(
-            samples_sequence_cval, samples_f_cval, n_samples, cval=True,
-            subtype_order=plot_subtype_order, biomarker_order=plot_biomarker_order, title_font_size=12,
+        fig, ax = self._plot_sustain_model(
+            samples_sequence=samples_sequence_cval,
+            samples_f=samples_f_cval,
+            n_samples=n_samples,
+            cval=True,
+            biomarker_labels=self.biomarker_labels,
+            subtype_order=plot_subtype_order,
+            biomarker_order=plot_biomarker_order,
             **kwargs
         )
 

--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -1038,7 +1038,10 @@ class AbstractSustain(ABC):
         pass
 
     @abstractmethod
-    def _plot_sustain_model(self, samples_sequence, samples_f, n_samples, cval=False, subtype_order=None, biomarker_order=None, title_font_size=10):
+    def _plot_sustain_model(self, samples_sequence, samples_f, n_samples, cval=False,
+    subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10,
+    stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10,
+    label_rot=0, cmap=None, biomarker_colours=None, figsize=None):
         pass
 
     @abstractmethod

--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -220,7 +220,15 @@ class AbstractSustain(ABC):
 
             # plot results
             if plot:
-                fig, ax = self._plot_sustain_model(samples_sequence, samples_f, n_samples, **kwargs)
+                fig, ax = self._plot_sustain_model(
+                    samples_sequence=samples_sequence,
+                    samples_f=samples_f,
+                    n_samples=n_samples,
+                    biomarker_labels=self.biomarker_labels,
+                    subtype_order=self._plot_subtype_order,
+                    biomarker_order=self._plot_biomarker_order,
+                    **kwargs
+                )
                 fig.savefig(Path(self.output_folder) / f"{self.dataset_name}_subtype{s}_PVD.{plot_format}")
                 fig.show()
 
@@ -1038,10 +1046,12 @@ class AbstractSustain(ABC):
         pass
 
     @abstractmethod
-    def _plot_sustain_model(self, samples_sequence, samples_f, n_samples, cval=False,
-    subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10,
-    stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10,
-    label_rot=0, cmap=None, biomarker_colours=None, figsize=None):
+    def _plot_sustain_model():
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def plot_positional_var():
         pass
 
     @abstractmethod

--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -230,11 +230,8 @@ class AbstractSustain(ABC):
                     save_path=Path(self.output_folder) / f"{self.dataset_name}_subtype{s}_PVD.{plot_format}",
                     **kwargs
                 )
-                if isinstance(figs, list):
-                    for fig in figs:
-                        fig.show()
-                else:
-                    figs.show()
+                for fig in figs:
+                    fig.show()
 
                 ax0.plot(range(self.N_iterations_MCMC), samples_likelihood, label="Subtype " + str(s+1))
 

--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -23,6 +23,7 @@ from tqdm.auto import tqdm
 import numpy as np
 import scipy.stats as stats
 from matplotlib import pyplot as plt
+import matplotlib.colors as mcolors
 from pathlib import Path
 import pickle
 import csv
@@ -1053,6 +1054,28 @@ class AbstractSustain(ABC):
     def calc_exp(x, mu, sig):
         x = (x - mu) / sig
         return np.exp(-.5 * x * x)
+
+    @staticmethod
+    def check_biomarker_colours(biomarker_colours, biomarker_labels):
+        if isinstance(biomarker_colours, dict):
+            # Check each label exists
+            assert all(i in biomarker_labels for i in biomarker_colours.keys()), "A label doesn't match!"
+            # Check each colour exists
+            assert all(mcolors.is_color_like(i) for i in biomarker_colours.values()), "A proper colour wasn't given!"
+            # Add in any colours that aren't defined, allowing for partial colouration
+            for label in biomarker_labels:
+                if label not in biomarker_colours:
+                    biomarker_colours[label] = "black"
+        elif isinstance(biomarker_colours, (list, tuple)):
+            # Check each colour exists
+            assert all(mcolors.is_color_like(i) for i in biomarker_colours), "A proper colour wasn't given!"
+            # Check right number of colours given
+            assert len(biomarker_colours) == len(biomarker_labels), "The number of colours and labels do not match!"
+            # Turn list of colours into a label:colour mapping
+            biomarker_colours = {k:v for k,v in zip(biomarker_labels, biomarker_colours)}
+        else:
+            raise TypeError("A dictionary mapping label:colour or list/tuple of colours must be given!")
+        return biomarker_colours
 
     # ********************* TEST METHODS
     @staticmethod

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -342,9 +342,9 @@ class MixtureSustain(AbstractSustain):
             # Determine order if info given
             if ml_f_EM is not None:
                 subtype_order = np.argsort(ml_f_EM)[::-1]
-            # Otherwise use dummy ordering
+            # Otherwise determine order from samples_f
             else:
-                subtype_order = np.arange(N_S)
+                subtype_order = np.argsort(np.mean(samples_f, 1))[::-1]
         # Warn user of reordering if labels and order given
         if biomarker_labels is not None and biomarker_order is not None:
             warnings.warn(

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -322,107 +322,105 @@ class MixtureSustain(AbstractSustain):
 
         return ml_sequence, ml_f, ml_likelihood, samples_sequence, samples_f, samples_likelihood
 
-    def _plot_sustain_model(self, samples_sequence, samples_f, n_samples, cval=False, subtype_order=None, biomarker_order=None, title_font_size=10):
-
-        temp_mean_f                         = np.mean(samples_f, 1)
-        vals                                = np.sort(temp_mean_f)[::-1]
-        vals                                = np.array([np.round(x * 100.) for x in vals]) / 100.
-        # ix                                  = np.argsort(temp_mean_f)[::-1]
+    def _plot_sustain_model(self, samples_sequence, samples_f, n_samples, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label="Event Position", stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="Oranges", biomarker_colours=None, figsize=None):
 
         if subtype_order is None:
-            subtype_order                   = self._plot_subtype_order
-
+            subtype_order = self._plot_subtype_order
         if biomarker_order is None:
-            biomarker_order                 = self._plot_biomarker_order #samples_sequence[ix[0], :, samples_sequence.shape[2]-1].astype(int)
+            biomarker_order = self._plot_biomarker_order
 
-        biomarker_labels_plot_order         = [self.biomarker_labels[i].replace('_', ' ') for i in biomarker_order]
+        biomarker_labels = [self.biomarker_labels[i].replace('_', ' ') for i in biomarker_order]
 
+        N_S = samples_sequence.shape[0]
+        N_bio = len(self.biomarker_labels)
 
-        N_S                                 = samples_sequence.shape[0]
-        N_bio                               = len(self.biomarker_labels)
-
-        N_stages                            = samples_sequence.shape[1]
-        N_MCMC_samples                      = samples_sequence.shape[2]
-        
-        confus_matrix_plotting              = np.zeros((N_stages, N_stages, N_S))
-
-        if N_S == 1:
-            fig, ax                         = plt.subplots()
-            total_axes                      = 1
-        elif N_S < 3:
-            fig, ax                         = plt.subplots(1, N_S)
-            total_axes                      = N_S
-        elif N_S < 7:
-            fig, ax                         = plt.subplots(2, int(np.ceil(N_S / 2)))
-            total_axes                      = 2 * int(np.ceil(N_S / 2))
+        # Check biomarker label colours
+        # If custom biomarker text colours are given
+        if biomarker_colours is not None:
+            biomarker_colours = type(self).check_biomarker_colours(
+            biomarker_colours, biomarker_labels
+        )
+        # Default case of all-black colours
+        # Unnecessary, but skips a check later
         else:
-            fig, ax                         = plt.subplots(3, int(np.ceil(N_S / 3)))
-            total_axes                      = 3 * int(np.ceil(N_S / 3))
+            biomarker_colours = {i:"black" for i in biomarker_labels}
 
-        for i in range(total_axes):        #for i in range(N_S):
+        # Determine number of rows and columns (rounded up)
+        if N_S == 1:
+            nrows, ncols = 1, 1
+        elif N_S < 3:
+            nrows, ncols = 1, N_S
+        elif N_S < 7:
+            nrows, ncols = 2, int(np.ceil(N_S / 2))
+        else:
+            nrows, ncols = 3, int(np.ceil(N_S / 3))
+        # Total axes used to loop over
+        total_axes = nrows * ncols
+        fig, axs = plt.subplots(nrows, ncols, figsize=figsize)
 
+        # Loop over each axis
+        for i in range(total_axes):
+            # Handle case of a single array
+            if isinstance(axs, np.ndarray):
+                ax = axs.flat[i]
+            else:
+                ax = axs
+            # Turn off axes from rounding up
             if i not in range(N_S):
-                ax.flat[i].set_axis_off()
+                ax.set_axis_off()
                 continue
 
-            this_samples_sequence           = samples_sequence[subtype_order[i],:,:].T
-		        	
-            N                               = this_samples_sequence.shape[1]
+            this_samples_sequence = samples_sequence[subtype_order[i],:,:].T
+            N = this_samples_sequence.shape[1]
 
-            confus_matrix                   = np.zeros((N, N))
-            for j in range(N):
-                confus_matrix[j, :]         = sum(this_samples_sequence == j)
-            confus_matrix                   /= N_MCMC_samples #float(max(this_samples_sequence.shape))
+            # Construct confusion matrix (vectorized)
+            # We compare `this_samples_sequence` against each position
+            # Sum each time it was observed at that point in the sequence
+            # And normalize for number of samples/sequences
+            confus_matrix = (this_samples_sequence==np.arange(N)[:, None, None]).sum(1) / this_samples_sequence.shape[0]
 
-            out_mat_i                       = np.tile(1 - confus_matrix[biomarker_order,:].reshape(N, N, 1), (1,1,3))
+            # Add axis title
+            if cval == False:
+                temp_mean_f = np.mean(samples_f, 1)
+                vals = np.sort(temp_mean_f)[::-1]
 
-            TITLE_FONT_SIZE                 = title_font_size
-            X_FONT_SIZE                     = 10 #8
-            Y_FONT_SIZE                     = 10 #7
-
-            if cval == False:                
                 if n_samples != np.inf:
-                    title_i                 = 'Subtype ' + str(i+1) + ' (f=' + str(vals[i])  + r', n=' + str(int(np.round(vals[i] * n_samples)))  + ')'
+                    title_i = f"Subtype {i+1} (f={vals[i]:.2f}, n={np.round(vals[i] * n_samples):n})"
                 else:
-                    title_i                 = 'Subtype ' + str(i+1) + ' (f=' + str(vals[i]) + ')'
+                    title_i = f"Subtype {i+1} (f={vals[i]:.2f})"
             else:
-                title_i                     = 'Subtype ' + str(i+1) + ' cross-validated'
+                title_i = f"Subtype {i+1} cross-validated"
 
-            if N_S > 1:
-                ax_i                        = ax.flat[i] #ax[i]
-                ax_i.imshow(out_mat_i, interpolation='nearest')      #, cmap=plt.cm.Blues)
-                ax_i.set_xticks(np.arange(N))
-                ax_i.set_xticklabels(range(1, N+1), fontsize=X_FONT_SIZE) #rotation=45,
+            # Plot the matrix
+            # Manually set vmin/vmax to handle edge cases
+            # and ensure consistent colourization across figures 
+            # when certainty=1
+            ax.imshow(
+                confus_matrix[biomarker_order, :],
+                interpolation='nearest',
+                cmap=cmap,
+                vmin=0,
+                vmax=1
+            )
+            # Add the xticks and labels
+            stage_ticks = np.arange(0, N, stage_interval)
+            ax.set_xticks(stage_ticks)
+            ax.set_xticklabels(stage_ticks+1, fontsize=stage_font_size, rotation=stage_rot)
+            # Add the yticks and labels
+            ax.set_yticks(np.arange(N_bio))
+            # Add biomarker labels to LHS of every row
+            if (i % ncols) == 0:
+                ax.set_yticklabels(biomarker_labels, ha='right', fontsize=label_font_size, rotation=label_rot)
+                # Set biomarker label colours
+                for tick_label in ax.get_yticklabels():
+                    tick_label.set_color(biomarker_colours[tick_label.get_text()])
+            else:
+                ax.set_yticklabels([])
+            # Make the event label slightly bigger than the ticks
+            ax.set_xlabel(stage_label, fontsize=stage_font_size+2)
+            ax.set_title(title_i, fontsize=title_font_size)
 
-                ax_i.set_yticks(np.arange(N_bio))
-                ax_i.set_yticklabels([]) #['']* N_bio)
-                if i == 0:
-                    ax_i.set_yticklabels(np.array(biomarker_labels_plot_order, dtype='object'), ha='right', fontsize=Y_FONT_SIZE)      #rotation=30, ha='right', rotation_mode='anchor'
-                    for tick in ax_i.yaxis.get_major_ticks():
-                        tick.label.set_color('black')
-
-                ax_i.set_xlabel('Event position', fontsize=X_FONT_SIZE)
-                ax_i.set_title(title_i, fontsize=TITLE_FONT_SIZE)
-
-            else: #**** one subtype
-                ax.imshow(out_mat_i) #, interpolation='nearest')#, cmap=plt.cm.Blues) #[...,::-1]
-                ax.set_xticks(np.arange(N))
-                ax.set_xticklabels(range(1, N+1), fontsize=X_FONT_SIZE) #rotation=45,
-
-                ax.set_yticks(np.arange(N_bio))
-                ax.set_yticklabels(np.array(biomarker_labels_plot_order, dtype='object'), ha='right', fontsize=Y_FONT_SIZE)           #rotation=30, ha='right', rotation_mode='anchor'
-
-                for tick in ax.yaxis.get_major_ticks():
-                    tick.label.set_color('black')
-
-                #ax.set_ylabel('Biomarker name') #, fontsize=20)
-                ax.set_xlabel('Event position', fontsize=X_FONT_SIZE)
-                ax.set_title(title_i, fontsize=TITLE_FONT_SIZE)
-                    
-        plt.tight_layout()
-        #if cval:
-        #    fig.suptitle('Cross validation')
-
+        fig.tight_layout()
         return fig, ax
 
     def subtype_and_stage_individuals_newData(self, L_yes_new, L_no_new, samples_sequence, samples_f, N_samples):

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -471,10 +471,16 @@ class MixtureSustain(AbstractSustain):
                 if separate_subtypes:
                     save_name = f"{save_path}_subtype{i}"
                 else:
-                    save_name = save_path
+                    save_name = f"{save_path}_all-subtypes"
+                # Handle file format, avoids issue with . in filenames
+                if "format" in save_kwargs:
+                    file_format = save_kwargs.pop("format")
+                # Default to png
+                else:
+                    file_format = "png"
                 # Save the figure, with additional kwargs
                 fig.savefig(
-                    save_name,
+                    f"{save_name}.{file_format}",
                     **save_kwargs
                 )
         return fig, axs

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -447,7 +447,7 @@ class MixtureSustain(AbstractSustain):
             ax.set_title(title_i, fontsize=title_font_size)
 
         fig.tight_layout()
-        return fig, ax
+        return fig, axs
 
     def subtype_and_stage_individuals_newData(self, L_yes_new, L_no_new, samples_sequence, samples_f, N_samples):
 

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -329,7 +329,7 @@ class MixtureSustain(AbstractSustain):
 
     # ********************* STATIC METHODS
     @staticmethod
-    def plot_positional_var(samples_sequence, samples_f, n_samples, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label="Event Position", stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="Oranges", biomarker_colours=None, figsize=None, separate_subtypes=False):
+    def plot_positional_var(samples_sequence, samples_f, n_samples, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label="Event Position", stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="Oranges", biomarker_colours=None, figsize=None, separate_subtypes=False, save_path=None, save_kwargs={}):
         # Get the number of subtypes
         N_S = samples_sequence.shape[0]
         # Get the number of features/biomarkers
@@ -464,7 +464,19 @@ class MixtureSustain(AbstractSustain):
                 ax.set_title(title_i, fontsize=title_font_size)
             # Tighten up the figure
             fig.tight_layout()
-
+            # Save if a path is given
+            if save_path is not None:
+                # Modify path for specific subtype if specified
+                # Don't modify save_path!
+                if separate_subtypes:
+                    save_name = f"{save_path}_subtype{i}"
+                else:
+                    save_name = save_path
+                # Save the figure, with additional kwargs
+                fig.savefig(
+                    save_name,
+                    **save_kwargs
+                )
         return fig, axs
 
     def subtype_and_stage_individuals_newData(self, L_yes_new, L_no_new, samples_sequence, samples_f, N_samples):

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -483,7 +483,7 @@ class MixtureSustain(AbstractSustain):
                     f"{save_name}.{file_format}",
                     **save_kwargs
                 )
-        return fig, axs
+        return figs, axs
 
     def subtype_and_stage_individuals_newData(self, L_yes_new, L_no_new, samples_sequence, samples_f, N_samples):
 

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -451,9 +451,9 @@ class OrdinalSustain(AbstractSustain):
             # Determine order if info given
             if ml_f_EM is not None:
                 subtype_order = np.argsort(ml_f_EM)[::-1]
-            # Otherwise use dummy ordering
+            # Otherwise determine order from samples_f
             else:
-                subtype_order = np.arange(N_S)
+                subtype_order = np.argsort(np.mean(samples_f, 1))[::-1]
         # Unravel the stage scores from score_vals
         stage_score = score_vals.T.flatten()
         IX_select = np.nonzero(stage_score)[0]

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -628,7 +628,7 @@ class OrdinalSustain(AbstractSustain):
                     f"{save_name}.{file_format}",
                     **save_kwargs
                 )
-        return fig, axs
+        return figs, axs
 
     # ********************* TEST METHODS
     @classmethod

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -616,10 +616,16 @@ class OrdinalSustain(AbstractSustain):
                 if separate_subtypes:
                     save_name = f"{save_path}_subtype{i}"
                 else:
-                    save_name = save_path
+                    save_name = f"{save_path}_all-subtypes"
+                # Handle file format, avoids issue with . in filenames
+                if "format" in save_kwargs:
+                    file_format = save_kwargs.pop("format")
+                # Default to png
+                else:
+                    file_format = "png"
                 # Save the figure, with additional kwargs
                 fig.savefig(
-                    save_name,
+                    f"{save_name}.{file_format}",
                     **save_kwargs
                 )
         return fig, axs

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -438,7 +438,7 @@ class OrdinalSustain(AbstractSustain):
         return a + (b - a) / (N - 1.) * arange_N
 
     @staticmethod
-    def plot_positional_var(samples_sequence, samples_f, n_samples, score_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None):
+    def plot_positional_var(samples_sequence, samples_f, n_samples, score_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None, separate_subtypes=False):
         # Get the number of subtypes
         N_S = samples_sequence.shape[0]
         # Get the number of features/biomarkers
@@ -506,92 +506,110 @@ class OrdinalSustain(AbstractSustain):
         else:
             biomarker_colours = {i:"black" for i in biomarker_labels}
 
-        # Determine number of rows and columns (rounded up)
-        if N_S == 1:
+        # Flag to plot subtypes separately
+        if separate_subtypes:
             nrows, ncols = 1, 1
-        elif N_S < 3:
-            nrows, ncols = 1, N_S
-        elif N_S < 7:
-            nrows, ncols = 2, int(np.ceil(N_S / 2))
         else:
-            nrows, ncols = 3, int(np.ceil(N_S / 3))
+            # Determine number of rows and columns (rounded up)
+            if N_S == 1:
+                nrows, ncols = 1, 1
+            elif N_S < 3:
+                nrows, ncols = 1, N_S
+            elif N_S < 7:
+                nrows, ncols = 2, int(np.ceil(N_S / 2))
+            else:
+                nrows, ncols = 3, int(np.ceil(N_S / 3))
         # Total axes used to loop over
         total_axes = nrows * ncols
-        fig, axs = plt.subplots(nrows, ncols, figsize=figsize)
-
-        # Loop over each axis
-        for i in range(total_axes):
-            # Handle case of a single array
-            if isinstance(axs, np.ndarray):
-                ax = axs.flat[i]
-            else:
-                ax = axs
-            # Check if i is superfluous
-            if i not in range(N_S):
-                ax.set_axis_off()
-                continue
-
-            this_samples_sequence = samples_sequence[subtype_order[i],:,:].T
-            N = this_samples_sequence.shape[1]
-
-            # Construct confusion matrix (vectorized)
-            # We compare `this_samples_sequence` against each position
-            # Sum each time it was observed at that point in the sequence
-            # And normalize for number of samples/sequences
-            confus_matrix = (this_samples_sequence==np.arange(N)[:, None, None]).sum(1) / this_samples_sequence.shape[0]
-
-            # Define the confusion matrix to insert the colours
-            # Use 1s to start with all white
-            confus_matrix_c = np.ones((N_bio, N, 3))
-
-            # Loop over each z-score event
-            for j, z in enumerate(num_scores):
-                # Determine which colours to alter
-                # I.e. red (1,0,0) means removing green & blue channels
-                # according to the certainty of red (representing z-score 1)
-                alter_level = colour_mat[j] == 0
-                # Extract the uncertainties for this z-score
-                confus_matrix_score = confus_matrix[(stage_score==z)[0]]
-                # Subtract the certainty for this colour
-                confus_matrix_c[:, :, alter_level] -= np.tile(
-                    confus_matrix_score.reshape(N_bio, N, 1),
-                    (1, 1, alter_level.sum())
-                )
-            # Add axis title
-            if cval == False:
-                temp_mean_f = np.mean(samples_f, 1)
-                vals = np.sort(temp_mean_f)[::-1]
-
-                if n_samples != np.inf:
-                    title_i = f"Group {i+1} (f={vals[i]:.2f}, n={np.round(vals[i] * n_samples):n})"
+        # Create list of single figure object if not separated
+        if separate_subtypes:
+            subtype_loops = N_S
+        else:
+            subtype_loops = 1
+        # Container for all figure objects
+        figs = []
+        # Loop over figures (only makes a diff if separate_subtypes=True)
+        for i in range(subtype_loops):
+            # Create the figure and axis for this subtype loop
+            fig, axs = plt.subplots(nrows, ncols, figsize=figsize)
+            figs.append(fig)
+            # Loop over each axis
+            for j in range(total_axes):
+                # Normal functionality (all subtypes on one plot)
+                if not separate_subtypes:
+                    i = j
+                # Handle case of a single array
+                if isinstance(axs, np.ndarray):
+                    ax = axs.flat[i]
                 else:
-                    title_i = f"Group {i+1} (f={vals[i]:.2f})"
-            else:
-                title_i = f"Group {i+1} cross-validated"
-            # Plot the colourized matrix
-            ax.imshow(
-                confus_matrix_c[biomarker_order, :, :],
-                interpolation='nearest'
-            )
-            # Add the xticks and labels
-            stage_ticks = np.arange(0, N, stage_interval)
-            ax.set_xticks(stage_ticks)
-            ax.set_xticklabels(stage_ticks+1, fontsize=stage_font_size, rotation=stage_rot)
-            # Add the yticks and labels
-            ax.set_yticks(np.arange(N_bio))
-            # Add biomarker labels to LHS of every row only
-            if (i % ncols) == 0:
-                ax.set_yticklabels(biomarker_labels, ha='right', fontsize=label_font_size, rotation=label_rot)
-                # Set biomarker label colours
-                for tick_label in ax.get_yticklabels():
-                    tick_label.set_color(biomarker_colours[tick_label.get_text()])
-            else:
-                ax.set_yticklabels([])
-            # Make the event label slightly bigger than the ticks
-            ax.set_xlabel(stage_label, fontsize=stage_font_size+2)
-            ax.set_title(title_i, fontsize=title_font_size)
+                    ax = axs
+                # Check if i is superfluous
+                if i not in range(N_S):
+                    ax.set_axis_off()
+                    continue
 
-        fig.tight_layout()
+                this_samples_sequence = samples_sequence[subtype_order[i],:,:].T
+                N = this_samples_sequence.shape[1]
+
+                # Construct confusion matrix (vectorized)
+                # We compare `this_samples_sequence` against each position
+                # Sum each time it was observed at that point in the sequence
+                # And normalize for number of samples/sequences
+                confus_matrix = (this_samples_sequence==np.arange(N)[:, None, None]).sum(1) / this_samples_sequence.shape[0]
+
+                # Define the confusion matrix to insert the colours
+                # Use 1s to start with all white
+                confus_matrix_c = np.ones((N_bio, N, 3))
+
+                # Loop over each z-score event
+                for j, z in enumerate(num_scores):
+                    # Determine which colours to alter
+                    # I.e. red (1,0,0) means removing green & blue channels
+                    # according to the certainty of red (representing z-score 1)
+                    alter_level = colour_mat[j] == 0
+                    # Extract the uncertainties for this z-score
+                    confus_matrix_score = confus_matrix[(stage_score==z)[0]]
+                    # Subtract the certainty for this colour
+                    confus_matrix_c[:, :, alter_level] -= np.tile(
+                        confus_matrix_score.reshape(N_bio, N, 1),
+                        (1, 1, alter_level.sum())
+                    )
+                # Add axis title
+                if cval == False:
+                    temp_mean_f = np.mean(samples_f, 1)
+                    vals = np.sort(temp_mean_f)[::-1]
+
+                    if n_samples != np.inf:
+                        title_i = f"Group {i+1} (f={vals[i]:.2f}, n={np.round(vals[i] * n_samples):n})"
+                    else:
+                        title_i = f"Group {i+1} (f={vals[i]:.2f})"
+                else:
+                    title_i = f"Group {i+1} cross-validated"
+                # Plot the colourized matrix
+                ax.imshow(
+                    confus_matrix_c[biomarker_order, :, :],
+                    interpolation='nearest'
+                )
+                # Add the xticks and labels
+                stage_ticks = np.arange(0, N, stage_interval)
+                ax.set_xticks(stage_ticks)
+                ax.set_xticklabels(stage_ticks+1, fontsize=stage_font_size, rotation=stage_rot)
+                # Add the yticks and labels
+                ax.set_yticks(np.arange(N_bio))
+                # Add biomarker labels to LHS of every row only
+                if (i % ncols) == 0:
+                    ax.set_yticklabels(biomarker_labels, ha='right', fontsize=label_font_size, rotation=label_rot)
+                    # Set biomarker label colours
+                    for tick_label in ax.get_yticklabels():
+                        tick_label.set_color(biomarker_colours[tick_label.get_text()])
+                else:
+                    ax.set_yticklabels([])
+                # Make the event label slightly bigger than the ticks
+                ax.set_xlabel(stage_label, fontsize=stage_font_size+2)
+                ax.set_title(title_i, fontsize=title_font_size)
+            # Tighten up the figure
+            fig.tight_layout()
+
         return fig, axs
 
     # ********************* TEST METHODS

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -592,7 +592,7 @@ class OrdinalSustain(AbstractSustain):
             ax.set_title(title_i, fontsize=title_font_size)
 
         fig.tight_layout()
-        return fig, ax
+        return fig, axs
 
     # ********************* TEST METHODS
     @classmethod

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -438,7 +438,7 @@ class OrdinalSustain(AbstractSustain):
         return a + (b - a) / (N - 1.) * arange_N
 
     @staticmethod
-    def plot_positional_var(samples_sequence, samples_f, n_samples, score_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None, separate_subtypes=False):
+    def plot_positional_var(samples_sequence, samples_f, n_samples, score_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None, separate_subtypes=False, save_path=None, save_kwargs={}):
         # Get the number of subtypes
         N_S = samples_sequence.shape[0]
         # Get the number of features/biomarkers
@@ -609,7 +609,19 @@ class OrdinalSustain(AbstractSustain):
                 ax.set_title(title_i, fontsize=title_font_size)
             # Tighten up the figure
             fig.tight_layout()
-
+            # Save if a path is given
+            if save_path is not None:
+                # Modify path for specific subtype if specified
+                # Don't modify save_path!
+                if separate_subtypes:
+                    save_name = f"{save_path}_subtype{i}"
+                else:
+                    save_name = save_path
+                # Save the figure, with additional kwargs
+                fig.savefig(
+                    save_name,
+                    **save_kwargs
+                )
         return fig, axs
 
     # ********************* TEST METHODS

--- a/pySuStaIn/ZScoreSustainMissingData.py
+++ b/pySuStaIn/ZScoreSustainMissingData.py
@@ -474,9 +474,9 @@ class ZscoreSustainMissingData(AbstractSustain):
         return a + (b - a) / (N - 1.) * arange_N
 
     @staticmethod
-    def plot_positional_var():
+    def plot_positional_var(*args, **kwargs):
         # TODO: ZscoreMissing should be a child of Zscore
-        pass
+        return ZscoreSustain.plot_positional_var(*args, **kwargs)
 
     # ********************* TEST METHODS
     @classmethod

--- a/pySuStaIn/ZScoreSustainMissingData.py
+++ b/pySuStaIn/ZScoreSustainMissingData.py
@@ -88,6 +88,7 @@ class ZscoreSustainMissingData(AbstractSustain):
         stage_biomarker_index   = stage_biomarker_index[IX_select]
         stage_biomarker_index   = stage_biomarker_index.reshape(1,len(stage_biomarker_index))
 
+        self.Z_vals                     = Z_vals
         self.stage_zscore               = stage_zscore
         self.stage_biomarker_index      = stage_biomarker_index
 
@@ -450,7 +451,7 @@ class ZscoreSustainMissingData(AbstractSustain):
 
     def _plot_sustain_model(self, *args, **kwargs):
         # TODO: ZscoreMissing should be a child of Zscore
-        return ZscoreSustain._plot_sustain_model(self, *args, **kwargs)
+        return ZscoreSustain.plot_positional_var(*args, Z_vals=self.Z_vals, **kwargs)
 
     def subtype_and_stage_individuals_newData(self, data_new, samples_sequence, samples_f, N_samples):
 
@@ -471,6 +472,11 @@ class ZscoreSustainMissingData(AbstractSustain):
     @staticmethod
     def linspace_local2(a, b, N, arange_N):
         return a + (b - a) / (N - 1.) * arange_N
+
+    @staticmethod
+    def plot_positional_var():
+        # TODO: ZscoreMissing should be a child of Zscore
+        pass
 
     # ********************* TEST METHODS
     @classmethod

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -445,116 +445,141 @@ class ZscoreSustain(AbstractSustain):
 
         return ml_sequence, ml_f, ml_likelihood, samples_sequence, samples_f, samples_likelihood
 
-    def _plot_sustain_model(self, samples_sequence, samples_f, n_samples, cval=False, subtype_order=None, biomarker_order=None, title_font_size=10):
+    def _plot_sustain_model(self, samples_sequence, samples_f, n_samples, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None):
 
         if subtype_order is None:
-            subtype_order                   = self._plot_subtype_order
+            subtype_order = self._plot_subtype_order
 
-        #biomarker_order currently unused here
+        # Get the z-scores and their number
+        zvalues = np.unique(self.stage_zscore)
+        N_z = len(zvalues)
 
-        colour_mat                          = np.array([[1, 0, 0], [1, 0, 1], [0, 0, 1]]) #, [0.5, 0, 1], [0, 1, 1]])
+        N_S = samples_sequence.shape[0]
+        N_bio = len(self.biomarker_labels)
 
-        temp_mean_f                         = np.mean(samples_f, 1)
-        vals                                = np.sort(temp_mean_f)[::-1]
-        vals                                = np.array([np.round(x * 100.) for x in vals]) / 100.
-        #ix                                  = np.argsort(temp_mean_f)[::-1]
-
-        N_S                                 = samples_sequence.shape[0]
-        N_bio                               = len(self.biomarker_labels)
-
-        if N_S == 1:
-            fig, ax                         = plt.subplots()
-            total_axes                      = 1
-        elif N_S < 3:
-            fig, ax                         = plt.subplots(1, N_S)
-            total_axes                      = N_S
-        elif N_S < 7:
-            fig, ax                         = plt.subplots(2, int(np.ceil(N_S / 2)))
-            total_axes                      = 2 * int(np.ceil(N_S / 2))
+        if biomarker_order is not None:
+            # self._plot_biomarker_order is not suited to zscore version
+            # Ignore for compatability, for now
+            # One option is to reshape, sum position, and lowest->highest determines order
+            if len(biomarker_order) > len(self.biomarker_labels):
+                biomarker_order = np.arange(N_bio)
+            # Get reordered labels
+            biomarker_labels = [self.biomarker_labels[i] for i in biomarker_order]
+        # Otherwise use default order
         else:
-            fig, ax                         = plt.subplots(3, int(np.ceil(N_S / 3)))
-            total_axes                      = 3 * int(np.ceil(N_S / 3))
+            biomarker_order = np.arange(N_bio)
+            biomarker_labels = self.biomarker_labels
 
+        # Z-score colour definition
+        if cmap == "original":
+            # Hard-coded colours: hooray!
+            colour_mat = np.array([[1, 0, 0], [1, 0, 1], [0, 0, 1], [0.5, 0, 1], [0, 1, 1], [0, 1, 0.5]])[:N_z]
+            # We only have up to 5 default colours, so double-check
+            if colour_mat.shape[0] > N_z:
+                raise ValueError(f"Colours are only defined for {len(colour_mat)} z-scores!")
+        else:
+            raise NotImplementedError
+        '''
+        Note for future self/others: The use of any arbitrary colourmap is problematic, as when the same stage can have the same biomarker with different z-scores of different certainties, the colours need to mix in a visually informative way and there can be issues with RGB mixing/interpolation, particulary if there are >2 z-scores for the same biomarker at the same stage. It may be possible, but the end result may no longer be useful to look at.
+        '''
 
-        for i in range(total_axes):        #range(N_S):
+        # Check biomarker label colours
+        # If custom biomarker text colours are given
+        if biomarker_colours is not None:
+            biomarker_colours = type(self).check_biomarker_colours(
+            biomarker_colours, biomarker_labels
+        )
+        # Default case of all-black colours
+        # Unnecessary, but skips a check later
+        else:
+            biomarker_colours = {i:"black" for i in biomarker_labels}
 
+        # Determine number of rows and columns (rounded up)
+        if N_S == 1:
+            nrows, ncols = 1, 1
+        elif N_S < 3:
+            nrows, ncols = 1, N_S
+        elif N_S < 7:
+            nrows, ncols = 2, int(np.ceil(N_S / 2))
+        else:
+            nrows, ncols = 3, int(np.ceil(N_S / 3))
+        # Total axes used to loop over
+        total_axes = nrows * ncols
+        fig, axs = plt.subplots(nrows, ncols, figsize=figsize)
+
+        # Loop over each axis
+        for i in range(total_axes):
+            # Handle case of a single array
+            if isinstance(axs, np.ndarray):
+                ax = axs.flat[i]
+            else:
+                ax = axs
+            # Check if i is superfluous
             if i not in range(N_S):
-                ax.flat[i].set_axis_off()
+                ax.set_axis_off()
                 continue
 
-            this_samples_sequence           = samples_sequence[subtype_order[i],:,:].T
-            markers                         = np.unique(self.stage_biomarker_index)
-            N                               = this_samples_sequence.shape[1]
+            this_samples_sequence = samples_sequence[subtype_order[i],:,:].T
+            N = this_samples_sequence.shape[1]
 
-            confus_matrix                   = np.zeros((N, N))
-            for j in range(N):
-                confus_matrix[j, :]         = sum(this_samples_sequence == j)
-            confus_matrix                   /= float(this_samples_sequence.shape[0])
+            # Construct confusion matrix (vectorized)
+            # We compare `this_samples_sequence` against each position
+            # Sum each time it was observed at that point in the sequence
+            # And normalize for number of samples/sequences
+            confus_matrix = (this_samples_sequence==np.arange(N)[:, None, None]).sum(1) / this_samples_sequence.shape[0]
 
-            zvalues                         = np.unique(self.stage_zscore)
-            N_z                             = len(zvalues)
-            confus_matrix_z                 = np.zeros((N_bio, N, N_z))
-            for z in range(N_z):
-                confus_matrix_z[self.stage_biomarker_index[self.stage_zscore == zvalues[z]], :, z] = confus_matrix[(self.stage_zscore == zvalues[z])[0],:]
+            # Define the confusion matrix to insert the colours
+            # Use 1s to start with all white
+            confus_matrix_c = np.ones((N_bio, N, 3))
 
-            confus_matrix_c                 = np.ones((N_bio, N, 3))
-            for z in range(N_z):
-                this_confus_matrix          = confus_matrix_z[:, :, z]
-                this_colour                 = colour_mat[z, :]
-                alter_level                 = this_colour == 0
+            # Loop over each z-score event
+            for j, z in enumerate(zvalues):
+                # Determine which colours to alter
+                # I.e. red (1,0,0) means removing green & blue channels
+                # according to the certainty of red (representing z-score 1)
+                alter_level = colour_mat[j] == 0
+                # Extract the uncertainties for this z-score
+                confus_matrix_zscore = confus_matrix[(self.stage_zscore==z)[0]]
+                # Subtract the certainty for this colour
+                confus_matrix_c[:, :, alter_level] -= np.tile(
+                    confus_matrix_zscore.reshape(N_bio, N, 1),
+                    (1, 1, alter_level.sum())
+                )
+            # Add axis title
+            if cval == False:
+                temp_mean_f = np.mean(samples_f, 1)
+                vals = np.sort(temp_mean_f)[::-1]
 
-                this_colour_matrix          = np.zeros((N_bio, N, 3))
-                this_colour_matrix[:, :, alter_level] = np.tile(this_confus_matrix[markers, :].reshape(N_bio, N, 1), (1, 1, sum(alter_level)))
-                confus_matrix_c             = confus_matrix_c - this_colour_matrix
-
-            TITLE_FONT_SIZE                 = title_font_size
-            X_FONT_SIZE                     = 10 #8
-            Y_FONT_SIZE                     = 10 #7 
-
-            if cval == False:                
                 if n_samples != np.inf:
-                    title_i                 = 'Subtype ' + str(i+1) + ' (f=' + str(vals[i])  + r', n=' + str(int(np.round(vals[i] * n_samples)))  + ')'
+                    title_i = f"Subtype {i+1} (f={vals[i]:.2f}, n={np.round(vals[i] * n_samples):n})"
                 else:
-                    title_i                 = 'Subtype ' + str(i+1) + ' (f=' + str(vals[i]) + ')'
+                    title_i = f"Subtype {i+1} (f={vals[i]:.2f})"
             else:
-                title_i                     = 'Subtype ' + str(i+1) + ' cross-validated'
+                title_i = f"Subtype {i+1} cross-validated"
+            # Plot the colourized matrix
+            ax.imshow(
+                confus_matrix_c[biomarker_order, :, :],
+                interpolation='nearest'
+            )
+            # Add the xticks and labels
+            stage_ticks = np.arange(0, N, stage_interval)
+            ax.set_xticks(stage_ticks)
+            ax.set_xticklabels(stage_ticks+1, fontsize=stage_font_size, rotation=stage_rot)
+            # Add the yticks and labels
+            ax.set_yticks(np.arange(N_bio))
+            # Add biomarker labels to LHS of every row only
+            if (i % ncols) == 0:
+                ax.set_yticklabels(biomarker_labels, ha='right', fontsize=label_font_size, rotation=label_rot)
+                # Set biomarker label colours
+                for tick_label in ax.get_yticklabels():
+                    tick_label.set_color(biomarker_colours[tick_label.get_text()])
+            else:
+                ax.set_yticklabels([])
+            # Make the event label slightly bigger than the ticks
+            ax.set_xlabel(stage_label, fontsize=stage_font_size+2)
+            ax.set_title(title_i, fontsize=title_font_size)
 
-            # must be a smarter way of doing this, but subplots(1,1) doesn't produce an array...
-            if N_S > 1:
-                ax_i                        = ax.flat[i] #ax[i]
-                ax_i.imshow(confus_matrix_c, interpolation='nearest')      #, cmap=plt.cm.Blues)
-                ax_i.set_xticks(np.arange(N))
-                ax_i.set_xticklabels(range(1, N+1), rotation=45, fontsize=X_FONT_SIZE)
-
-                ax_i.set_yticks(np.arange(N_bio))
-                ax_i.set_yticklabels([]) #['']* N_bio)
-                if i == 0:
-                    ax_i.set_yticklabels(np.array(self.biomarker_labels, dtype='object'), ha='right', fontsize=Y_FONT_SIZE)
-                    for tick in ax_i.yaxis.get_major_ticks():
-                        tick.label.set_color('black')
-
-                #ax[i].set_ylabel('Biomarker name') #, fontsize=20)
-                ax_i.set_xlabel('SuStaIn stage', fontsize=X_FONT_SIZE)
-                ax_i.set_title(title_i, fontsize=TITLE_FONT_SIZE)
-        
-            else: #**** first plot
-                ax.imshow(confus_matrix_c) #, interpolation='nearest')#, cmap=plt.cm.Blues) #[...,::-1]
-                ax.set_xticks(np.arange(N))
-                ax.set_xticklabels(range(1, N+1), rotation=45, fontsize=X_FONT_SIZE)
-
-                ax.set_yticks(np.arange(N_bio))
-                ax.set_yticklabels(np.array(self.biomarker_labels, dtype='object'), ha='right', fontsize=Y_FONT_SIZE)
-
-                for tick in ax.yaxis.get_major_ticks():
-                    tick.label.set_color('black')
-
-                ax.set_xlabel('SuStaIn stage', fontsize=X_FONT_SIZE)
-                ax.set_title(title_i, fontsize=TITLE_FONT_SIZE)
-                
-        plt.tight_layout()
-        #if cval:
-        #    fig.suptitle('Cross validation')
-
+        fig.tight_layout()
         return fig, ax
 
 

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -471,7 +471,7 @@ class ZscoreSustain(AbstractSustain):
         return a + (b - a) / (N - 1.) * arange_N
 
     @staticmethod
-    def plot_positional_var(samples_sequence, samples_f, n_samples, Z_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None):
+    def plot_positional_var(samples_sequence, samples_f, n_samples, Z_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None, separate_subtypes=False):
         # Get the number of subtypes
         N_S = samples_sequence.shape[0]
         # Get the number of features/biomarkers
@@ -539,93 +539,111 @@ class ZscoreSustain(AbstractSustain):
         else:
             biomarker_colours = {i:"black" for i in biomarker_labels}
 
-        # Determine number of rows and columns (rounded up)
-        if N_S == 1:
+        # Flag to plot subtypes separately
+        if separate_subtypes:
             nrows, ncols = 1, 1
-        elif N_S < 3:
-            nrows, ncols = 1, N_S
-        elif N_S < 7:
-            nrows, ncols = 2, int(np.ceil(N_S / 2))
         else:
-            nrows, ncols = 3, int(np.ceil(N_S / 3))
+            # Determine number of rows and columns (rounded up)
+            if N_S == 1:
+                nrows, ncols = 1, 1
+            elif N_S < 3:
+                nrows, ncols = 1, N_S
+            elif N_S < 7:
+                nrows, ncols = 2, int(np.ceil(N_S / 2))
+            else:
+                nrows, ncols = 3, int(np.ceil(N_S / 3))
         # Total axes used to loop over
         total_axes = nrows * ncols
-        fig, axs = plt.subplots(nrows, ncols, figsize=figsize)
-
-        # Loop over each axis
-        for i in range(total_axes):
-            # Handle case of a single array
-            if isinstance(axs, np.ndarray):
-                ax = axs.flat[i]
-            else:
-                ax = axs
-            # Check if i is superfluous
-            if i not in range(N_S):
-                ax.set_axis_off()
-                continue
-
-            this_samples_sequence = samples_sequence[subtype_order[i],:,:].T
-            N = this_samples_sequence.shape[1]
-
-            # Construct confusion matrix (vectorized)
-            # We compare `this_samples_sequence` against each position
-            # Sum each time it was observed at that point in the sequence
-            # And normalize for number of samples/sequences
-            confus_matrix = (this_samples_sequence==np.arange(N)[:, None, None]).sum(1) / this_samples_sequence.shape[0]
-
-            # Define the confusion matrix to insert the colours
-            # Use 1s to start with all white
-            confus_matrix_c = np.ones((N_bio, N, 3))
-
-            # Loop over each z-score event
-            for j, z in enumerate(zvalues):
-                # Determine which colours to alter
-                # I.e. red (1,0,0) means removing green & blue channels
-                # according to the certainty of red (representing z-score 1)
-                alter_level = colour_mat[j] == 0
-                # Extract the uncertainties for this z-score
-                confus_matrix_zscore = confus_matrix[(stage_zscore==z)[0]]
-                # Subtract the certainty for this colour
-                confus_matrix_c[:, :, alter_level] -= np.tile(
-                    confus_matrix_zscore.reshape(N_bio, N, 1),
-                    (1, 1, alter_level.sum())
-                )
-            # Add axis title
-            if cval == False:
-                temp_mean_f = np.mean(samples_f, 1)
-                vals = np.sort(temp_mean_f)[::-1]
-
-                if n_samples != np.inf:
-                    title_i = f"Subtype {i+1} (f={vals[i]:.2f}, n={np.round(vals[i] * n_samples):n})"
+        # Create list of single figure object if not separated
+        if separate_subtypes:
+            subtype_loops = N_S
+        else:
+            subtype_loops = 1
+        # Container for all figure objects
+        figs = []
+        # Loop over figures (only makes a diff if separate_subtypes=True)
+        for i in range(subtype_loops):
+            # Create the figure and axis for this subtype loop
+            fig, axs = plt.subplots(nrows, ncols, figsize=figsize)
+            figs.append(fig)
+            # Loop over each axis
+            for j in range(total_axes):
+                # Normal functionality (all subtypes on one plot)
+                if not separate_subtypes:
+                    i = j
+                # Handle case of a single array
+                if isinstance(axs, np.ndarray):
+                    ax = axs.flat[i]
                 else:
-                    title_i = f"Subtype {i+1} (f={vals[i]:.2f})"
-            else:
-                title_i = f"Subtype {i+1} cross-validated"
-            # Plot the colourized matrix
-            ax.imshow(
-                confus_matrix_c[biomarker_order, :, :],
-                interpolation='nearest'
-            )
-            # Add the xticks and labels
-            stage_ticks = np.arange(0, N, stage_interval)
-            ax.set_xticks(stage_ticks)
-            ax.set_xticklabels(stage_ticks+1, fontsize=stage_font_size, rotation=stage_rot)
-            # Add the yticks and labels
-            ax.set_yticks(np.arange(N_bio))
-            # Add biomarker labels to LHS of every row only
-            if (i % ncols) == 0:
-                ax.set_yticklabels(biomarker_labels, ha='right', fontsize=label_font_size, rotation=label_rot)
-                # Set biomarker label colours
-                for tick_label in ax.get_yticklabels():
-                    tick_label.set_color(biomarker_colours[tick_label.get_text()])
-            else:
-                ax.set_yticklabels([])
-            # Make the event label slightly bigger than the ticks
-            ax.set_xlabel(stage_label, fontsize=stage_font_size+2)
-            ax.set_title(title_i, fontsize=title_font_size)
+                    ax = axs
+                # Check if i is superfluous
+                if i not in range(N_S):
+                    ax.set_axis_off()
+                    continue
 
-        fig.tight_layout()
-        return fig, axs
+                this_samples_sequence = samples_sequence[subtype_order[i],:,:].T
+                N = this_samples_sequence.shape[1]
+
+                # Construct confusion matrix (vectorized)
+                # We compare `this_samples_sequence` against each position
+                # Sum each time it was observed at that point in the sequence
+                # And normalize for number of samples/sequences
+                confus_matrix = (this_samples_sequence==np.arange(N)[:, None, None]).sum(1) / this_samples_sequence.shape[0]
+
+                # Define the confusion matrix to insert the colours
+                # Use 1s to start with all white
+                confus_matrix_c = np.ones((N_bio, N, 3))
+
+                # Loop over each z-score event
+                for j, z in enumerate(zvalues):
+                    # Determine which colours to alter
+                    # I.e. red (1,0,0) means removing green & blue channels
+                    # according to the certainty of red (representing z-score 1)
+                    alter_level = colour_mat[j] == 0
+                    # Extract the uncertainties for this z-score
+                    confus_matrix_zscore = confus_matrix[(stage_zscore==z)[0]]
+                    # Subtract the certainty for this colour
+                    confus_matrix_c[:, :, alter_level] -= np.tile(
+                        confus_matrix_zscore.reshape(N_bio, N, 1),
+                        (1, 1, alter_level.sum())
+                    )
+                # Add axis title
+                if cval == False:
+                    temp_mean_f = np.mean(samples_f, 1)
+                    vals = np.sort(temp_mean_f)[::-1]
+
+                    if n_samples != np.inf:
+                        title_i = f"Subtype {i+1} (f={vals[i]:.2f}, n={np.round(vals[i] * n_samples):n})"
+                    else:
+                        title_i = f"Subtype {i+1} (f={vals[i]:.2f})"
+                else:
+                    title_i = f"Subtype {i+1} cross-validated"
+                # Plot the colourized matrix
+                ax.imshow(
+                    confus_matrix_c[biomarker_order, :, :],
+                    interpolation='nearest'
+                )
+                # Add the xticks and labels
+                stage_ticks = np.arange(0, N, stage_interval)
+                ax.set_xticks(stage_ticks)
+                ax.set_xticklabels(stage_ticks+1, fontsize=stage_font_size, rotation=stage_rot)
+                # Add the yticks and labels
+                ax.set_yticks(np.arange(N_bio))
+                # Add biomarker labels to LHS of every row only
+                if (i % ncols) == 0:
+                    ax.set_yticklabels(biomarker_labels, ha='right', fontsize=label_font_size, rotation=label_rot)
+                    # Set biomarker label colours
+                    for tick_label in ax.get_yticklabels():
+                        tick_label.set_color(biomarker_colours[tick_label.get_text()])
+                else:
+                    ax.set_yticklabels([])
+                # Make the event label slightly bigger than the ticks
+                ax.set_xlabel(stage_label, fontsize=stage_font_size+2)
+                ax.set_title(title_i, fontsize=title_font_size)
+            # Tighten up the figure
+            fig.tight_layout()
+
+        return figs, axs
 
     # ********************* TEST METHODS
     @classmethod

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -649,10 +649,16 @@ class ZscoreSustain(AbstractSustain):
                 if separate_subtypes:
                     save_name = f"{save_path}_subtype{i}"
                 else:
-                    save_name = save_path
+                    save_name = f"{save_path}_all-subtypes"
+                # Handle file format, avoids issue with . in filenames
+                if "format" in save_kwargs:
+                    file_format = save_kwargs.pop("format")
+                # Default to png
+                else:
+                    file_format = "png"
                 # Save the figure, with additional kwargs
                 fig.savefig(
-                    save_name,
+                    f"{save_name}.{file_format}",
                     **save_kwargs
                 )
         return figs, axs

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -484,9 +484,9 @@ class ZscoreSustain(AbstractSustain):
             # Determine order if info given
             if ml_f_EM is not None:
                 subtype_order = np.argsort(ml_f_EM)[::-1]
-            # Otherwise use dummy ordering
+            # Otherwise determine order from samples_f
             else:
-                subtype_order = np.arange(N_S)
+                subtype_order = np.argsort(np.mean(samples_f, 1))[::-1]
         # Unravel the stage zscores from Z_vals
         stage_zscore = Z_vals.T.flatten()
         IX_select = np.nonzero(stage_zscore)[0]

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -625,7 +625,7 @@ class ZscoreSustain(AbstractSustain):
             ax.set_title(title_i, fontsize=title_font_size)
 
         fig.tight_layout()
-        return fig, ax
+        return fig, axs
 
     # ********************* TEST METHODS
     @classmethod

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -471,7 +471,7 @@ class ZscoreSustain(AbstractSustain):
         return a + (b - a) / (N - 1.) * arange_N
 
     @staticmethod
-    def plot_positional_var(samples_sequence, samples_f, n_samples, Z_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None, separate_subtypes=False):
+    def plot_positional_var(samples_sequence, samples_f, n_samples, Z_vals, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None, separate_subtypes=False, save_path=None, save_kwargs={}):
         # Get the number of subtypes
         N_S = samples_sequence.shape[0]
         # Get the number of features/biomarkers
@@ -642,7 +642,19 @@ class ZscoreSustain(AbstractSustain):
                 ax.set_title(title_i, fontsize=title_font_size)
             # Tighten up the figure
             fig.tight_layout()
-
+            # Save if a path is given
+            if save_path is not None:
+                # Modify path for specific subtype if specified
+                # Don't modify save_path!
+                if separate_subtypes:
+                    save_name = f"{save_path}_subtype{i}"
+                else:
+                    save_name = save_path
+                # Save the figure, with additional kwargs
+                fig.savefig(
+                    save_name,
+                    **save_kwargs
+                )
         return figs, axs
 
     # ********************* TEST METHODS

--- a/pySuStaIn/updated_zscore_pvd.py
+++ b/pySuStaIn/updated_zscore_pvd.py
@@ -1,0 +1,156 @@
+def plot_positional_var(Z_vals, samples_sequence, samples_f, n_samples, biomarker_labels=None, ml_f_EM=None, cval=False, subtype_order=None, biomarker_order=None, title_font_size=12, stage_font_size=10, stage_label='SuStaIn Stage', stage_rot=0, stage_interval=1, label_font_size=10, label_rot=0, cmap="original", biomarker_colours=None, figsize=None):
+    # Get the number of subtypes
+    N_S = samples_sequence.shape[0]
+    # Get the number of features/biomarkers
+    N_bio = Z_vals.shape[0]
+    # Check that the number of labels given match
+    if biomarker_labels is not None:
+        assert len(biomarker_labels) == N_bio
+    # Set subtype order if not given
+    if subtype_order is None:
+        # Determine order if info given
+        if ml_f_EM is not None:
+            subtype_order = np.argsort(ml_f_EM)[::-1]
+        # Otherwise use dummy ordering
+        else:
+            subtype_order = np.arange(N_S)
+    # Unravel the stage zscores from Z_vals
+    stage_zscore = Z_vals.T.flatten()
+    IX_select = np.nonzero(stage_zscore)[0]
+    stage_zscore = stage_zscore[IX_select]
+    # Get the z-scores and their number
+    zvalues = np.unique(stage_zscore)
+    N_z = len(zvalues)
+    # Warn user of reordering if labels and order given
+    if biomarker_labels is not None and biomarker_order is not None:
+        warnings.warning(
+            "Both labels and an order have been given. The labels will be reordered according to the given order!"
+        )
+
+    if biomarker_order is not None:
+        # self._plot_biomarker_order is not suited to zscore version
+        # Ignore for compatability, for now
+        # One option is to reshape, sum position, and lowest->highest determines order
+        if len(biomarker_order) > N_bio:
+            biomarker_order = np.arange(N_bio)
+    # Otherwise use default order
+    else:
+        biomarker_order = np.arange(N_bio)
+    # If no labels given, set dummy defaults
+    if biomarker_labels is None:
+        biomarker_labels = [f"Bioamrker {i}" for i in N_bio]
+    # Otherwise reorder according to given order (or not if not given)
+    else:
+        biomarker_labels = [biomarker_labels[i] for i in biomarker_order]
+
+    # Z-score colour definition
+    if cmap == "original":
+        # Hard-coded colours: hooray!
+        colour_mat = np.array([[1, 0, 0], [1, 0, 1], [0, 0, 1], [0.5, 0, 1], [0, 1, 1], [0, 1, 0.5]])[:N_z]
+        # We only have up to 5 default colours, so double-check
+        if colour_mat.shape[0] > N_z:
+            raise ValueError(f"Colours are only defined for {len(colour_mat)} z-scores!")
+    else:
+        raise NotImplementedError
+    '''
+    Note for future self/others: The use of any arbitrary colourmap is problematic, as when the same stage can have the same biomarker with different z-scores of different certainties, the colours need to mix in a visually informative way and there can be issues with RGB mixing/interpolation, particulary if there are >2 z-scores for the same biomarker at the same stage. It may be possible, but the end result may no longer be useful to look at.
+    '''
+
+    # Check biomarker label colours
+    # If custom biomarker text colours are given
+    if biomarker_colours is not None:
+        biomarker_colours = AbstractSustain.check_biomarker_colours(
+        biomarker_colours, biomarker_labels
+    )
+    # Default case of all-black colours
+    # Unnecessary, but skips a check later
+    else:
+        biomarker_colours = {i:"black" for i in biomarker_labels}
+
+    # Determine number of rows and columns (rounded up)
+    if N_S == 1:
+        nrows, ncols = 1, 1
+    elif N_S < 3:
+        nrows, ncols = 1, N_S
+    elif N_S < 7:
+        nrows, ncols = 2, int(np.ceil(N_S / 2))
+    else:
+        nrows, ncols = 3, int(np.ceil(N_S / 3))
+    # Total axes used to loop over
+    total_axes = nrows * ncols
+    fig, axs = plt.subplots(nrows, ncols, figsize=figsize)
+
+    # Loop over each axis
+    for i in range(total_axes):
+        # Handle case of a single array
+        if isinstance(axs, np.ndarray):
+            ax = axs.flat[i]
+        else:
+            ax = axs
+        # Check if i is superfluous
+        if i not in range(N_S):
+            ax.set_axis_off()
+            continue
+
+        this_samples_sequence = samples_sequence[subtype_order[i],:,:].T
+        N = this_samples_sequence.shape[1]
+
+        # Construct confusion matrix (vectorized)
+        # We compare `this_samples_sequence` against each position
+        # Sum each time it was observed at that point in the sequence
+        # And normalize for number of samples/sequences
+        confus_matrix = (this_samples_sequence==np.arange(N)[:, None, None]).sum(1) / this_samples_sequence.shape[0]
+
+        # Define the confusion matrix to insert the colours
+        # Use 1s to start with all white
+        confus_matrix_c = np.ones((N_bio, N, 3))
+
+        # Loop over each z-score event
+        for j, z in enumerate(zvalues):
+            # Determine which colours to alter
+            # I.e. red (1,0,0) means removing green & blue channels
+            # according to the certainty of red (representing z-score 1)
+            alter_level = colour_mat[j] == 0
+            # Extract the uncertainties for this z-score
+            confus_matrix_zscore = confus_matrix[(stage_zscore==z)[0]]
+            # Subtract the certainty for this colour
+            confus_matrix_c[:, :, alter_level] -= np.tile(
+                confus_matrix_zscore.reshape(N_bio, N, 1),
+                (1, 1, alter_level.sum())
+            )
+        # Add axis title
+        if cval == False:
+            temp_mean_f = np.mean(samples_f, 1)
+            vals = np.sort(temp_mean_f)[::-1]
+
+            if n_samples != np.inf:
+                title_i = f"Subtype {i+1} (f={vals[i]:.2f}, n={np.round(vals[i] * n_samples):n})"
+            else:
+                title_i = f"Subtype {i+1} (f={vals[i]:.2f})"
+        else:
+            title_i = f"Subtype {i+1} cross-validated"
+        # Plot the colourized matrix
+        ax.imshow(
+            confus_matrix_c[biomarker_order, :, :],
+            interpolation='nearest'
+        )
+        # Add the xticks and labels
+        stage_ticks = np.arange(0, N, stage_interval)
+        ax.set_xticks(stage_ticks)
+        ax.set_xticklabels(stage_ticks+1, fontsize=stage_font_size, rotation=stage_rot)
+        # Add the yticks and labels
+        ax.set_yticks(np.arange(N_bio))
+        # Add biomarker labels to LHS of every row only
+        if (i % ncols) == 0:
+            ax.set_yticklabels(biomarker_labels, ha='right', fontsize=label_font_size, rotation=label_rot)
+            # Set biomarker label colours
+            for tick_label in ax.get_yticklabels():
+                tick_label.set_color(biomarker_colours[tick_label.get_text()])
+        else:
+            ax.set_yticklabels([])
+        # Make the event label slightly bigger than the ticks
+        ax.set_xlabel(stage_label, fontsize=stage_font_size+2)
+        ax.set_title(title_i, fontsize=title_font_size)
+
+    fig.tight_layout()
+    return fig, ax

--- a/sim/simrun.py
+++ b/sim/simrun.py
@@ -182,7 +182,7 @@ def main():
     #plot PVDs given subtype and biomarker ordering
     fig, ax                 = sustain._plot_sustain_model(ground_truth_sequences, ground_truth_fractions_actual, ground_truth_nsamples, \
                                                           subtype_order=plot_subtype_order, biomarker_order=plot_biomarker_order, title_font_size=12)
-    plt.suptitle('Ground truth sequences')
+    fig.suptitle('Ground truth sequences')
     fig.savefig(os.path.join(output_folder, 'PVD_true.png'))
     fig.show()
 
@@ -215,13 +215,15 @@ def main():
     for i in range(N_S_max):
         X_hist.append(ml_subtype[ground_truth_subtypes==i].ravel())
         labels_hist.append('Subtype ' + str(i+1))
-    plt.hist(X_hist, bins, label=labels_hist)
-    plt.xticks(np.arange(0, N_S_ground_truth)+0.5, np.arange(1, N_S_ground_truth+1))
-    plt.xlabel('Estimated subtype', fontsize=FONT_SIZE)
-    plt.title('')
-    plt.legend(loc='upper right', fontsize=FONT_SIZE)
-    plt.savefig(os.path.join(output_folder, 'Subtype_estimate_histograms.png'))
-    plt.show()
+    fig, ax = plt.subplots()
+    ax.hist(X_hist, bins, label=labels_hist)
+    ax.set_xticks(np.arange(0, N_S_ground_truth)+0.5)
+    ax.set_xticklabels(np.arange(1, N_S_ground_truth+1))
+    ax.set_xlabel('Estimated subtype', fontsize=FONT_SIZE)
+    ax.set_title('')
+    ax.legend(loc='upper right', fontsize=FONT_SIZE)
+    fig.savefig(os.path.join(output_folder, 'Subtype_estimate_histograms.png'))
+    fig.show()
 
     #plot the inferred stages as boxplots binned by true stage
     df_boxplot                  = pd.DataFrame()
@@ -229,12 +231,13 @@ def main():
     df_boxplot['subtypes_est']  = ml_subtype
     df_boxplot['stages_true']   = ground_truth_stages
     df_boxplot['stages_est']    = ml_stage
-    df_boxplot.boxplot(column='stages_est', by='stages_true', grid=False, fontsize=FONT_SIZE)
-    plt.xlabel('True stages',       fontsize=FONT_SIZE)
-    plt.ylabel('Estimated stages',  fontsize=FONT_SIZE)
-    plt.title('')
-    plt.savefig(os.path.join(output_folder, 'Stage_estimate_boxplots.png'))
-    plt.show()
+    fig, ax = plt.subplots()
+    df_boxplot.boxplot(column='stages_est', by='stages_true', grid=False, fontsize=FONT_SIZE, ax=ax)
+    ax.set_xlabel('True stages',       fontsize=FONT_SIZE)
+    ax.set_ylabel('Estimated stages',  fontsize=FONT_SIZE)
+    ax.set_title('')
+    fig.savefig(os.path.join(output_folder, 'Stage_estimate_boxplots.png'))
+    fig.show()
 
     print('Maximum likelihood model finished. Saved figures and output files in ' + output_folder + ' folder.')
 
@@ -272,8 +275,6 @@ def main():
         #this part estimates cross-validated positional variance diagrams
         for i in range(N_S_max):
             sustain.combine_cross_validated_sequences(i+1, N_folds)
-
-    plt.show()
 
     print('Cross-validation finished. Saved figures and output files in ' + output_folder + ' folder.')
 


### PR DESCRIPTION
After a few requests for tweaking parts of plots, made a few changes to update the PVD plotting code. Changes summarized below:

- For all PVD plotting functions (`*._plot_sustain_model`):
    - Added optional arguments control font size (and rotation) for all elements (`title_font_size`, `stage_font_size`, `label_font_size`, `stage_rot`, `label_rot`)
    - Added option to control xtick interval (`stage_interval`) for when there are many events
    - Optional argument for figure size (`figsize`)
    - Optional argument to colourize biomarker labels (`biomarker_colours`). Colours must pass [`matplotlib.colors.is_color_like`](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.is_color_like.html), i.e. be a name or RGB(A).
        - A `dict` maps label:colour. Any labels not given are defaulted to black.
        - A `list`/`tuple` presumes default order of labels, and must all be given.
- `plot_format` option added to `run_sustain_algorithm` and `combine_cross_validated_sequences` to specify saving format
    - Both also pass all kwargs to `_plot_sustain_model`
- `MixtureSustain`
    - Fixed colourmap, so can now be added. Limits defined to handle edge case of all <1 values passed, allowing visual comparison with other PVDs
- `ZscoreSustain`
    - Added missing implementation for `biomarker_order`
    - Upto 5 z-scores can be given. Use of arbitrary colourmap potentially problematic (as noted in a comment), and not visually informative. If more z-scores are desired, custom solution can be added.
- `ZscoreMissingSustain`
    - Just returns `ZscoreSustain` version