### PR TITLE
Fix NumPy 2.x compatibility in subtype_and_stage_individuals

### DIFF
--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -569,7 +569,7 @@ class AbstractSustain(ABC):
         prob_ml_stage                       = np.nan * np.ones((nSamples, 1))
 
         for i in range(nSamples):
-            this_prob_subtype               = np.squeeze(prob_subtype[i, :])
+            this_prob_subtype               = np.atleast_1d(np.squeeze(prob_subtype[i, :]))
             # if not np.isnan(this_prob_subtype).any()
             if (np.sum(np.isnan(this_prob_subtype)) == 0):
                 # this_subtype = this_prob_subtype.argmax(


### PR DESCRIPTION
### Problem
This PR fixes a compatibility issue with NumPy 2.x that causes `pySuStaIn` to crash with the following error with one line of change:

```
ValueError: Calling nonzero on 0d arrays is not allowed. Use np.atleast_1d(scalar).nonzero() instead.
```

### Cause
The issue occurs in `AbstractSustain.subtype_and_stage_individuals()` at line 572 when:
1. The model has exactly one subtype (`N_S == 1`)
2. `prob_subtype[i, :]` has shape `(1,)`
3. `np.squeeze(...)` collapses it to a 0-dimensional scalar
4. `np.where(this_prob_subtype == np.max(this_prob_subtype))` calls `nonzero()` on the scalar

NumPy 2.x introduced stricter rules that prohibit calling `nonzero()` on 0-dimensional arrays, while NumPy 1.x allowed this behavior.

### Solution
**Minimal, safe fix**: Wrap `np.squeeze()` result with `np.atleast_1d()`:
```python
# Before (line 572)
this_prob_subtype = np.squeeze(prob_subtype[i, :])

# After
this_prob_subtype = np.atleast_1d(np.squeeze(prob_subtype[i, :]))
```

This ensures the array is always at least 1-dimensional, preventing the 0-D array issue while maintaining all existing functionality.

i have tested it with:
- Maintains backward compatibility with NumPy 1.x
- Fixes the crash with NumPy 2.x
- Preserves all existing behavior for multi-subtype scenarios
- Minimal code change reduces risk of introducing new bugs

### References
- NumPy 2.0 Migration Guide: https://numpy.org/devdocs/numpy_2_0_migration_guide.html
- Related NumPy issue on 0-D array restrictions
