### PR TITLE
Low-impact performance optimizations for all SuStaIn classes

### DIFF
--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -275,7 +275,10 @@ class AbstractSustain(ABC):
         for fold in tqdm(select_fold, "Folds: ", Nfolds, position=0, leave=True):
 
             indx_test                       = test_idxs[fold]
-            indx_train                      = np.array([x for x in range(self.__sustainData.getNumSamples()) if x not in indx_test])
+            all_idxs                        = np.arange(self.__sustainData.getNumSamples())
+            mask                            = np.ones(self.__sustainData.getNumSamples(), dtype=bool)
+            mask[indx_test]                 = False
+            indx_train                      = all_idxs[mask]
 
             sustainData_train               = self.__sustainData.reindex(indx_train)
             sustainData_test                = self.__sustainData.reindex(indx_test)
@@ -392,7 +395,7 @@ class AbstractSustain(ABC):
                 else:
                     mean_likelihood_subj_test_cval    = np.concatenate((mean_likelihood_subj_test_cval, mean_likelihood_subj_test), axis=0)
 
-            CVIC[s]                     = -2*sum(np.log(mean_likelihood_subj_test_cval))
+            CVIC[s]                     = -2*np.sum(np.log(mean_likelihood_subj_test_cval))
 
         print("CVIC for each subtype model: " + str(CVIC))
 
@@ -553,51 +556,30 @@ class AbstractSustain(ABC):
             total_prob_subtype_stage        = self._calculate_likelihood(sustainData, this_S, this_f)
 
             total_prob_subtype              = total_prob_subtype.reshape(len(total_prob_subtype), N_S)
-            total_prob_subtype_norm         = total_prob_subtype        / np.tile(np.sum(total_prob_subtype, 1).reshape(len(total_prob_subtype), 1),        (1, N_S))
-            total_prob_stage_norm           = total_prob_stage          / np.tile(np.sum(total_prob_stage, 1).reshape(len(total_prob_stage), 1),          (1, nStages + 1)) #removed total_prob_subtype
+            total_prob_subtype_norm         = total_prob_subtype / np.sum(total_prob_subtype, 1, keepdims=True)
+            total_prob_stage_norm           = total_prob_stage / np.sum(total_prob_stage, 1, keepdims=True) #removed total_prob_subtype
 
-            #total_prob_subtype_stage_norm   = total_prob_subtype_stage  / np.tile(np.sum(np.sum(total_prob_subtype_stage, 1), 1).reshape(nSamples, 1, 1),   (1, nStages + 1, N_S))
-            total_prob_subtype_stage_norm   = total_prob_subtype_stage / np.tile(np.sum(np.sum(total_prob_subtype_stage, 1, keepdims=True), 2).reshape(nSamples, 1, 1),(1, nStages + 1, N_S))
+            total_prob_subtype_stage_norm   = total_prob_subtype_stage / np.sum(total_prob_subtype_stage, axis=(1, 2), keepdims=True)
 
             prob_subtype_stage              = (i / (i + 1.) * prob_subtype_stage)   + (1. / (i + 1.) * total_prob_subtype_stage_norm)
             prob_subtype                    = (i / (i + 1.) * prob_subtype)         + (1. / (i + 1.) * total_prob_subtype_norm)
             prob_stage                      = (i / (i + 1.) * prob_stage)           + (1. / (i + 1.) * total_prob_stage_norm)
 
-        ml_subtype                          = np.nan * np.ones((nSamples, 1))
-        prob_ml_subtype                     = np.nan * np.ones((nSamples, 1))
-        ml_stage                            = np.nan * np.ones((nSamples, 1))
-        prob_ml_stage                       = np.nan * np.ones((nSamples, 1))
+        ml_subtype                          = np.full((nSamples, 1), np.nan)
+        prob_ml_subtype                     = np.full((nSamples, 1), np.nan)
+        ml_stage                            = np.full((nSamples, 1), np.nan)
+        prob_ml_stage                       = np.full((nSamples, 1), np.nan)
+
+        valid_subtype                       = np.sum(np.isnan(prob_subtype), axis=1) == 0
+        ml_subtype[valid_subtype]           = np.argmax(prob_subtype[valid_subtype], axis=1, keepdims=True)
+        prob_ml_subtype[valid_subtype]      = np.take_along_axis(prob_subtype[valid_subtype], (ml_subtype[valid_subtype]).astype(int), axis=1)
 
         for i in range(nSamples):
-            this_prob_subtype               = np.atleast_1d(np.squeeze(prob_subtype[i, :]))
-            # if not np.isnan(this_prob_subtype).any()
-            if (np.sum(np.isnan(this_prob_subtype)) == 0):
-                # this_subtype = this_prob_subtype.argmax(
-                this_subtype                = np.where(this_prob_subtype == np.max(this_prob_subtype))
-
-                try:
-                    ml_subtype[i]           = this_subtype
-                except:
-                    ml_subtype[i]           = this_subtype[0][0]
-                if this_prob_subtype.size == 1 and this_prob_subtype == 1:
-                    prob_ml_subtype[i]      = 1
-                else:
-                    try:
-                        prob_ml_subtype[i]  = this_prob_subtype[this_subtype]
-                    except:
-                        prob_ml_subtype[i]  = this_prob_subtype[this_subtype[0][0]]
-
-            this_prob_stage                 = np.squeeze(prob_subtype_stage[i, :, int(ml_subtype[i])])
-            
-            if (np.sum(np.isnan(this_prob_stage)) == 0):
-                # this_stage = 
-                this_stage                  = np.where(this_prob_stage == np.max(this_prob_stage))
-                ml_stage[i]                 = this_stage[0][0]
-                prob_ml_stage[i]            = this_prob_stage[this_stage[0][0]]
-        # NOTE: The above loop can be replaced with some simpler numpy calls
-        # May need to do some masking to avoid NaNs, or use `np.nanargmax` depending on preference
-        # E.g. ml_subtype == prob_subtype.argmax(1)
-        # E.g. ml_stage == prob_subtype_stage[np.arange(prob_subtype_stage.shape[0]), :, ml_subtype].argmax(1)
+            if valid_subtype[i]:
+                this_prob_stage                 = np.squeeze(prob_subtype_stage[i, :, int(ml_subtype[i])])
+                if np.sum(np.isnan(this_prob_stage)) == 0:
+                    ml_stage[i]                 = np.argmax(this_prob_stage)
+                    prob_ml_stage[i]            = this_prob_stage[int(ml_stage[i])]
         return ml_subtype, prob_ml_subtype, ml_stage, prob_ml_stage, prob_subtype, prob_stage, prob_subtype_stage
 
     # ********************* PROTECTED METHODS
@@ -630,20 +612,13 @@ class AbstractSustain(ABC):
 
             ml_sequence_prev                = ml_sequence_prev.reshape(ml_sequence_prev.shape[0], ml_sequence_prev.shape[1])
             p_sequence                      = p_sequence.reshape(p_sequence.shape[0], N_S - 1)
-            p_sequence_norm                 = p_sequence / np.tile(np.sum(p_sequence, 1).reshape(len(p_sequence), 1), (N_S - 1))
+            p_sequence_norm                 = p_sequence / np.sum(p_sequence, 1, keepdims=True)
 
-            # Assign individuals to a subtype (cluster) based on the previous model
-            ml_cluster_subj                 = np.zeros((sustainData.getNumSamples(), 1))   #np.zeros((len(data_local), 1))
-            for m in range(sustainData.getNumSamples()):                                   #range(len(data_local)):
-                ix                          = np.argmax(p_sequence_norm[m, :]) + 1
-
-                #TEMP: MATLAB comparison
-                #ml_cluster_subj[m]          = ix*np.ceil(np.random.rand())
-                ml_cluster_subj[m]          = ix  # FIXME: should check this always works, as it differs to the Matlab code, which treats ix as an array
+            ml_cluster_subj                 = (np.argmax(p_sequence_norm, axis=1) + 1).reshape(-1, 1)
 
             ml_likelihood                   = -np.inf
             for ix_cluster_split in range(N_S - 1):
-                this_N_cluster              = sum(ml_cluster_subj == int(ix_cluster_split + 1))
+                this_N_cluster              = np.sum(ml_cluster_subj == int(ix_cluster_split + 1))
 
                 if this_N_cluster > 1:
 
@@ -669,7 +644,7 @@ class AbstractSustain(ABC):
                     this_seq_init           = np.hstack((this_seq_init.T, this_ml_sequence_split[1])).T
                     
                     #initialize fraction of subjects in each subtype to be uniform
-                    this_f_init             = np.array([1.] * N_S) / float(N_S)
+                    this_f_init             = np.ones(N_S) / N_S
 
                     print(' + Finding ML solution from hierarchical initialisation')
                     this_ml_sequence,       \
@@ -778,7 +753,7 @@ class AbstractSustain(ABC):
             ml_f_mat[:, i]                  = pool_output_list[i][1]
             ml_likelihood_mat[i]            = pool_output_list[i][2]
 
-        ix                                  = [np.where(ml_likelihood_mat == max(ml_likelihood_mat))[0][0]] #ugly bit of code to get first index where likelihood is maximum
+        ix                                  = np.atleast_1d(np.argmax(ml_likelihood_mat)) #ugly bit of code to get first index where likelihood is maximum
 
         ml_sequence                         = ml_sequence_mat[:, :, ix]
         ml_f                                = ml_f_mat[:, ix]
@@ -815,7 +790,7 @@ class AbstractSustain(ABC):
             temp_seq_init                   = self._initialise_sequence(sustainData, rng)
             seq_init[s, :], _, _, _, _, _   = self._perform_em(temp_sustainData, temp_seq_init, [1], rng)
 
-        f_init                              = np.array([1.] * N_S) / float(N_S)
+        f_init                              = np.ones(N_S) / N_S
 
         # optimise the mixture of two models from the initialisation
         this_ml_sequence, \
@@ -852,8 +827,7 @@ class AbstractSustain(ABC):
             ml_f_mat[:, i]                  = pool_output_list[i][1]
             ml_likelihood_mat[i]            = pool_output_list[i][2]
 
-        ix                                  = np.where(ml_likelihood_mat == max(ml_likelihood_mat))
-        ix                                  = ix[0]
+        ix                                  = np.atleast_1d(np.argmax(ml_likelihood_mat))
 
         ml_sequence                         = ml_sequence_mat[:, :, ix]
         ml_f                                = ml_f_mat[:, ix]
@@ -888,9 +862,9 @@ class AbstractSustain(ABC):
 
         terminate                           = 0
         iteration                           = 0
-        samples_sequence                    = np.nan * np.ones((MaxIter, N, N_S))
-        samples_f                           = np.nan * np.ones((MaxIter, N_S))
-        samples_likelihood                  = np.nan * np.ones((MaxIter, 1))
+        samples_sequence                    = np.full((MaxIter, N, N_S), np.nan)
+        samples_f                           = np.full((MaxIter, N_S), np.nan)
+        samples_likelihood                  = np.full((MaxIter, 1), np.nan)
 
         samples_sequence[0, :, :]           = current_sequence.reshape(current_sequence.shape[1], current_sequence.shape[0])
         current_f                           = np.array(current_f).reshape(len(current_f))
@@ -940,9 +914,7 @@ class AbstractSustain(ABC):
         N_S                                 = S.shape[0]
         N                                   = sustainData.getNumStages()    #self.stage_zscore.shape[1]
 
-        f                                   = np.array(f).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        f_broadcast                         = np.asarray(f).reshape(1, 1, N_S)
 
         p_perm_k                            = np.zeros((M, N + 1, N_S))
 
@@ -950,8 +922,8 @@ class AbstractSustain(ABC):
             p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S[s])  #self.__calculate_likelihood_stage_linearzscoremodel_approx(data_local, S[s])
 
 
-        total_prob_cluster                  = np.squeeze(np.sum(p_perm_k * f_val_mat, 1))
-        total_prob_stage                    = np.sum(p_perm_k * f_val_mat, 2)
+        total_prob_cluster                  = np.squeeze(np.sum(p_perm_k * f_broadcast, 1))
+        total_prob_stage                    = np.sum(p_perm_k * f_broadcast, 2)
         total_prob_subj                     = np.sum(total_prob_stage, 1)
 
         loglike                             = np.sum(np.log(total_prob_subj + 1e-250))
@@ -1005,13 +977,7 @@ class AbstractSustain(ABC):
                                                                                                      seq_sigma_currentpass,
                                                                                                      f_sigma_currentpass)
 
-            samples_position_currentpass    = np.zeros(samples_sequence_currentpass.shape)
-            for s in range(N_S):
-                for sample in range(n_iterations_MCMC_optimisation):
-                    temp_seq                        = samples_sequence_currentpass[s, :, sample]
-                    temp_inv                        = np.array([0] * samples_sequence_currentpass.shape[1])
-                    temp_inv[temp_seq.astype(int)]  = np.arange(samples_sequence_currentpass.shape[1])
-                    samples_position_currentpass[s, :, sample] = temp_inv
+            samples_position_currentpass    = np.argsort(samples_sequence_currentpass, axis=1)
 
             seq_sigma_currentpass           = np.std(samples_position_currentpass, axis=2, ddof=1)  # np.std is different to Matlab std, which normalises to N-1 by default
             seq_sigma_currentpass[seq_sigma_currentpass < 0.01] = 0.01  # magic number

--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -862,14 +862,10 @@ class AbstractSustain(ABC):
 
         terminate                           = 0
         iteration                           = 0
-        samples_sequence                    = np.full((MaxIter, N, N_S), np.nan)
-        samples_f                           = np.full((MaxIter, N_S), np.nan)
-        samples_likelihood                  = np.full((MaxIter, 1), np.nan)
-
-        samples_sequence[0, :, :]           = current_sequence.reshape(current_sequence.shape[1], current_sequence.shape[0])
+        samples_sequence                    = [current_sequence.reshape(current_sequence.shape[1], current_sequence.shape[0])]
         current_f                           = np.array(current_f).reshape(len(current_f))
-        samples_f[0, :]                     = current_f
-        samples_likelihood[0]               = current_likelihood
+        samples_f                           = [current_f.copy()]
+        samples_likelihood                  = [current_likelihood]
         while terminate == 0:
 
             candidate_sequence,     \
@@ -886,9 +882,9 @@ class AbstractSustain(ABC):
                     current_f               = candidate_f
                     current_likelihood      = candidate_likelihood
 
-            samples_sequence[iteration, :, :] = current_sequence.T.reshape(current_sequence.T.shape[0], N_S)
-            samples_f[iteration, :]         = current_f
-            samples_likelihood[iteration]   = current_likelihood
+            samples_sequence.append(current_sequence.T.reshape(current_sequence.T.shape[0], N_S))
+            samples_f.append(current_f.copy())
+            samples_likelihood.append(current_likelihood)
 
             if iteration == (MaxIter - 1):
                 terminate                   = 1
@@ -897,6 +893,10 @@ class AbstractSustain(ABC):
         ml_sequence                         = current_sequence
         ml_f                                = current_f
         ml_likelihood                       = current_likelihood
+        samples_sequence                    = np.array(samples_sequence)
+        samples_f                           = np.array(samples_f)
+        samples_likelihood                  = np.array(samples_likelihood)
+
         return ml_sequence, ml_f, ml_likelihood, samples_sequence, samples_f, samples_likelihood
 
     def _calculate_likelihood(self, sustainData, S, f):

--- a/pySuStaIn/AbstractSustain.py
+++ b/pySuStaIn/AbstractSustain.py
@@ -914,16 +914,16 @@ class AbstractSustain(ABC):
         N_S                                 = S.shape[0]
         N                                   = sustainData.getNumStages()    #self.stage_zscore.shape[1]
 
-        f_broadcast                         = np.asarray(f).reshape(1, 1, N_S)
+        f                                   = np.asarray(f).flatten()  # (N_S,)
 
         p_perm_k                            = np.zeros((M, N + 1, N_S))
 
         for s in range(N_S):
-            p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S[s])  #self.__calculate_likelihood_stage_linearzscoremodel_approx(data_local, S[s])
+            p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S[s])
 
-
-        total_prob_cluster                  = np.squeeze(np.sum(p_perm_k * f_broadcast, 1))
-        total_prob_stage                    = np.sum(p_perm_k * f_broadcast, 2)
+        # Use einsum to fuse multiply-and-sum, avoiding (M, N+1, N_S) temporaries
+        total_prob_stage                    = np.einsum('jks,s->jk', p_perm_k, f)  # (M, N+1)
+        total_prob_cluster                  = np.einsum('jks,s->js', p_perm_k, f)  # (M, N_S)
         total_prob_subj                     = np.sum(total_prob_stage, 1)
 
         loglike                             = np.sum(np.log(total_prob_subj + 1e-250))

--- a/pySuStaIn/MixedTypeSustain.py
+++ b/pySuStaIn/MixedTypeSustain.py
@@ -498,28 +498,23 @@ class MixedTypeSustain(AbstractSustain):
         N = sustainData.getNumStages()
         
         S_opt = S_init.copy()
-        f_opt = np.array(f_init).reshape(N_S, 1, 1)
-        f_val_mat = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt = np.asarray(f_init).reshape(1, 1, N_S)
         p_perm_k = np.zeros((M, N + 1, N_S))
 
         for s in range(N_S):
             p_perm_k[:, :, s] = self._calculate_likelihood_stage(sustainData, S_opt[s])
 
-        p_perm_k_weighted = p_perm_k * f_val_mat
+        p_perm_k_weighted = p_perm_k * f_opt
         p_perm_k_norm = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
-        f_opt = (np.squeeze(np.sum(p_perm_k_norm, axis=(0, 1))) / np.sum(p_perm_k_norm)).reshape(N_S, 1, 1)
+        f_opt = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
 
-        f_val_mat = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat = np.transpose(f_val_mat, (2, 1, 0))
         order_seq = rng.permutation(N_S)  # this will produce different random numbers to Matlab
 
         for s in order_seq:
             order_bio = rng.permutation(N)  # this will produce different random numbers to Matlab
             for i in order_bio:
                 current_sequence = S_opt[s]
-                current_location = np.array([0] * len(current_sequence))
-                current_location[current_sequence.astype(int)] = np.arange(len(current_sequence))
+                current_location = np.argsort(current_sequence.astype(int))
 
                 selected_event = i
 
@@ -532,16 +527,16 @@ class MixedTypeSustain(AbstractSustain):
                 # slightly different conditional check to matlab version to protect python from calling min,max on an empty array
                 min_filter = possible_zscores_biomarker < this_stage_zscore
                 max_filter = possible_zscores_biomarker > this_stage_zscore
-                events = np.array(range(self.num_stages))
+                events = np.arange(self.num_stages)
                 if np.any(min_filter):
                     min_zscore_bound = max(possible_zscores_biomarker[min_filter])
-                    min_zscore_bound_event = events[((self.stage_score[0] == min_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    min_zscore_bound_event = events[np.logical_and(self.stage_score[0] == min_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_lower_bound = current_location[min_zscore_bound_event] + 1
                 else:
                     move_event_to_lower_bound = 0
                 if np.any(max_filter):
                     max_zscore_bound = min(possible_zscores_biomarker[max_filter])
-                    max_zscore_bound_event = events[((self.stage_score[0] == max_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    max_zscore_bound_event = events[np.logical_and(self.stage_score[0] == max_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_upper_bound = current_location[max_zscore_bound_event]
                 else:
                     move_event_to_upper_bound = N
@@ -570,7 +565,7 @@ class MixedTypeSustain(AbstractSustain):
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
 
                     p_perm_k[:, :, s] = possible_p_perm_k[:, :, index]
-                    total_prob_stage = np.sum(p_perm_k * f_val_mat, 2)
+                    total_prob_stage = np.sum(p_perm_k * f_opt, 2)
                     total_prob_subj = np.sum(total_prob_stage, 1)
                     possible_likelihood[index] = np.sum(np.log(total_prob_subj + 1e-250))
 
@@ -584,15 +579,13 @@ class MixedTypeSustain(AbstractSustain):
 
             S_opt[s] = this_S
 
-        p_perm_k_weighted = p_perm_k * f_val_mat
+        p_perm_k_weighted = p_perm_k * f_opt
         p_perm_k_norm = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
 
-        f_opt = (np.squeeze(np.sum(p_perm_k_norm, axis=(0, 1))) / np.sum(p_perm_k_norm)).reshape(N_S, 1, 1)
-        f_val_mat = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
 
         f_opt = f_opt.reshape(N_S)
-        total_prob_stage = np.sum(p_perm_k * f_val_mat, 2)
+        total_prob_stage = np.sum(p_perm_k * f_opt, 2)
         total_prob_subj = np.sum(total_prob_stage, 1)
 
         likelihood_opt = np.sum(np.log(total_prob_subj + 1e-250))
@@ -622,8 +615,7 @@ class MixedTypeSustain(AbstractSustain):
                     move_event_from = int(np.ceil(N * self.global_rng.random())) - 1
                     current_sequence = samples_sequence[subtype_idx, :, iter_idx - 1]
 
-                    current_location = np.array([0] * N)
-                    current_location[current_sequence.astype(int)] = np.arange(N)
+                    current_location = np.argsort(current_sequence.astype(int))
 
                     selected_event = int(current_sequence[move_event_from])
                     this_stage_score = self.stage_score[0, selected_event]
@@ -633,18 +625,18 @@ class MixedTypeSustain(AbstractSustain):
                     # Keep each biomarker's events monotonic when proposing moves.
                     min_filter = possible_scores_biomarker < this_stage_score
                     max_filter = possible_scores_biomarker > this_stage_score
-                    events = np.array(range(N))
+                    events = np.arange(N)
 
                     if np.any(min_filter):
                         min_score_bound = max(possible_scores_biomarker[min_filter])
-                        min_score_bound_event = events[((self.stage_score[0] == min_score_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        min_score_bound_event = events[np.logical_and(self.stage_score[0] == min_score_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_lower_bound = current_location[min_score_bound_event] + 1
                     else:
                         move_event_to_lower_bound = 0
 
                     if np.any(max_filter):
                         max_score_bound = min(possible_scores_biomarker[max_filter])
-                        max_score_bound_event = events[((self.stage_score[0] == max_score_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        max_score_bound_event = events[np.logical_and(self.stage_score[0] == max_score_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_upper_bound = current_location[max_score_bound_event]
                     else:
                         move_event_to_upper_bound = N
@@ -680,15 +672,14 @@ class MixedTypeSustain(AbstractSustain):
             samples_likelihood[iter_idx] = likelihood_sample
 
             if iter_idx > 0:
-                ratio = np.exp(samples_likelihood[iter_idx] - samples_likelihood[iter_idx - 1])
-                if ratio < self.global_rng.random():
+                log_ratio = samples_likelihood[iter_idx] - samples_likelihood[iter_idx - 1]
+                if log_ratio < np.log(self.global_rng.random()):
                     samples_likelihood[iter_idx] = samples_likelihood[iter_idx - 1]
                     samples_sequence[:, :, iter_idx] = samples_sequence[:, :, iter_idx - 1]
                     samples_f[:, iter_idx] = samples_f[:, iter_idx - 1]
 
-        perm_index = np.where(samples_likelihood == max(samples_likelihood))
-        perm_index = perm_index[0]
-        ml_likelihood = max(samples_likelihood)
+        perm_index = np.argmax(samples_likelihood)
+        ml_likelihood = np.max(samples_likelihood)
         ml_sequence = samples_sequence[:, :, perm_index]
         ml_f = samples_f[:, perm_index]
 

--- a/pySuStaIn/MixedTypeSustain.py
+++ b/pySuStaIn/MixedTypeSustain.py
@@ -558,8 +558,21 @@ class MixedTypeSustain(AbstractSustain):
                     move_event_to = possible_positions[index]
 
                     # move this event in its new position
-                    current_sequence = np.delete(current_sequence, move_event_from, 0)  # this is different to the Matlab version, which call current_sequence(move_event_from) = []
-                    new_sequence = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     possible_sequences[index, :] = new_sequence
 
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
@@ -658,8 +671,21 @@ class MixedTypeSustain(AbstractSustain):
                     index = self.global_rng.choice(range(len(possible_positions)), 1, replace=True, p=weight)
                     move_event_to = possible_positions[index]
 
-                    current_sequence = np.delete(current_sequence, move_event_from, 0)
-                    new_sequence = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     samples_sequence[subtype_idx, :, iter_idx] = new_sequence
 
                 new_f = samples_f[:, iter_idx - 1] + f_sigma * self.global_rng.standard_normal()

--- a/pySuStaIn/MixedTypeSustain.py
+++ b/pySuStaIn/MixedTypeSustain.py
@@ -460,7 +460,7 @@ class MixedTypeSustain(AbstractSustain):
             zscored_data = np.array(sustainData.zdata[:, :, None], dtype=np.float64)
             x = zscored_data - stage_value_zscore
             x = np.transpose(x, (0, 2, 1))
-            p_perm_k_biomarkers[:, :, self.bool_zscore_biomarkers] = stats.norm.pdf(x)
+            p_perm_k_biomarkers[:, :, self.bool_zscore_biomarkers] = np.exp(-0.5 * x * x) / np.sqrt(2.0 * np.pi)
 
         if n_ordinal_event > 0:
             stage_value_ordinal_event = np.zeros((self.num_stages + 1, self.num_biomarkers))

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -247,8 +247,11 @@ class MixtureSustain(AbstractSustain):
                     possible_likelihood = np.zeros((N, 1))
                     possible_p_perm_k = np.zeros((M, N + 1, N))
 
-                    current_sequence = np.delete(current_sequence, move_event_from, 0)
-                    new_sequence = np.append(current_sequence, selected_event)
+                    # Remove element at move_event_from and append selected_event at end
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                    new_sequence[move_event_from:N-1] = current_sequence[move_event_from+1:N]
+                    new_sequence[N-1] = selected_event
 
                     temp_p_perm_k, cp_yes, cp_no, cp_no_org = self._calculate_likelihood_subset(sustainData.L_yes, sustainData.L_no, new_sequence)
                     p_perm_k[:, :, s] = temp_p_perm_k
@@ -300,8 +303,21 @@ class MixtureSustain(AbstractSustain):
                         move_event_to           = possible_positions[index]
 
                         #move this event in its new position
-                        current_sequence        = np.delete(current_sequence, move_event_from, 0)  # this is different to the Matlab version, which call current_sequence(move_event_from) = []
-                        new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                        # Move selected_event from move_event_from to move_event_to
+                        # without intermediate allocations from delete+concatenate
+                        new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                        if move_event_from < int(move_event_to):
+                            new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                            new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                            new_sequence[int(move_event_to)] = selected_event
+                            new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                        elif move_event_from > int(move_event_to):
+                            new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                            new_sequence[int(move_event_to)] = selected_event
+                            new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                            new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                        else:
+                            new_sequence[:] = current_sequence
                         possible_sequences[index, :] = new_sequence
 
                         possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)

--- a/pySuStaIn/MixtureSustain.py
+++ b/pySuStaIn/MixtureSustain.py
@@ -220,24 +220,17 @@ class MixtureSustain(AbstractSustain):
         N                                   = sustainData.getNumStages()
 
         S_opt                               = S_init.copy()  # have to copy or changes will be passed to S_init
-        f_opt                               = np.array(f_init).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt                               = np.asarray(f_init).reshape(1, 1, N_S)
         p_perm_k                            = np.zeros((M, N + 1, N_S))
 
         for s in range(N_S):
             p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S_opt[s])
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
-        # the second summation axis is different to Matlab version
-        #p_perm_k_norm                       = p_perm_k_weighted / np.tile(np.sum(np.sum(p_perm_k_weighted, 1), 1).reshape(M, 1, 1), (1, N + 1, N_S))
-        # adding 1e-250 fixes divide by zero problem that happens rarely
+        p_perm_k_weighted                   = p_perm_k * f_opt
         p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
 
-        f_opt                               = (np.squeeze(np.sum(p_perm_k_norm, axis = (1, 0))) / np.sum(p_perm_k_norm)).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
-        order_seq                           = rng.permutation(N_S)    #np.random.permutation(N_S)  # this will produce different random numbers to Matlab
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
+        order_seq                           = rng.permutation(N_S)
 
         for s in order_seq:
             order_bio                       = rng.permutation(N) #np.random.permutation(N)  # this will produce different random numbers to Matlab
@@ -246,8 +239,7 @@ class MixtureSustain(AbstractSustain):
                 for i in order_bio:
                     current_sequence = S_opt[s]
                     assert(len(current_sequence) == N)
-                    current_location = np.zeros(N, dtype = int)
-                    current_location[current_sequence.astype(int)] = np.arange(N)
+                    current_location = np.argsort(current_sequence.astype(int))
 
                     selected_event = i
                     move_event_from = current_location[selected_event]
@@ -262,7 +254,7 @@ class MixtureSustain(AbstractSustain):
                     p_perm_k[:, :, s] = temp_p_perm_k
                     possible_p_perm_k[:, :, N - 1] = temp_p_perm_k
 
-                    total_prob_stage = np.sum(p_perm_k * f_val_mat, 2)
+                    total_prob_stage = np.sum(p_perm_k * f_opt, 2)
                     total_prob_subj = np.sum(total_prob_stage, axis=1)
                     possible_likelihood[N - 1] = np.sum(np.log(total_prob_subj + 1e-250))
 
@@ -272,10 +264,9 @@ class MixtureSustain(AbstractSustain):
                                                                                             position, cp_yes, cp_no, 
                                                                                             cp_no_org)
                         
-                        # calculate log_likelihood
                         p_perm_k[:, :, s] = temp_p_perm_k
                         possible_p_perm_k[:, :, position] = temp_p_perm_k
-                        total_prob_stage = np.sum(p_perm_k * f_val_mat, 2)
+                        total_prob_stage = np.sum(p_perm_k * f_opt, 2)
                         total_prob_subj = np.sum(total_prob_stage, 1)
                         possible_likelihood[position] = np.sum(np.log(total_prob_subj + 1e-250))
 
@@ -292,8 +283,7 @@ class MixtureSustain(AbstractSustain):
                 for i in order_bio:
                     current_sequence            = S_opt[s]
                     assert(len(current_sequence)==N)
-                    current_location            = np.array([0] * N)
-                    current_location[current_sequence.astype(int)] = np.arange(N)
+                    current_location            = np.argsort(current_sequence.astype(int))
 
                     selected_event              = i
 
@@ -317,7 +307,7 @@ class MixtureSustain(AbstractSustain):
                         possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
 
                         p_perm_k[:, :, s]       = possible_p_perm_k[:, :, index]
-                        total_prob_stage        = np.sum(p_perm_k * f_val_mat, 2)
+                        total_prob_stage        = np.sum(p_perm_k * f_opt, 2)
                         total_prob_subj         = np.sum(total_prob_stage, 1)
                         possible_likelihood[index] = np.sum(np.log(total_prob_subj + 1e-250))
 
@@ -331,15 +321,12 @@ class MixtureSustain(AbstractSustain):
 
                 S_opt[s]                        = this_S
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
-        p_perm_k_norm                       = p_perm_k_weighted / np.tile(np.sum(np.sum(p_perm_k_weighted, 1), 1).reshape(M, 1, 1), (1, N + 1, N_S))  # the second summation axis is different to Matlab version
-        f_opt                               = (np.squeeze(np.sum(p_perm_k_norm, axis = (1, 0))) / np.sum(p_perm_k_norm)).reshape(N_S, 1, 1)
-
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        p_perm_k_weighted                   = p_perm_k * f_opt
+        p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
 
         f_opt                               = f_opt.reshape(N_S)
-        total_prob_stage                    = np.sum(p_perm_k * f_val_mat, 2)
+        total_prob_stage                    = np.sum(p_perm_k * f_opt, 2)
         total_prob_subj                     = np.sum(total_prob_stage, 1)
 
         likelihood_opt                      = np.sum(np.log(total_prob_subj + 1e-250))
@@ -410,12 +397,9 @@ class MixtureSustain(AbstractSustain):
             for s in range(N_S):
                 p_perm_k[:,:,s]             = self._calculate_likelihood_stage(sustainData, S[s,:])
 
+            f_broadcast                     = samples_f[:,i].reshape(1, 1, N_S)
 
-            #NOTE: added extra axes to get np.tile to work the same as Matlab's repmat in this 3D tiling
-            f_val_mat                       = np.tile(samples_f[:,i, np.newaxis, np.newaxis], (1, N+1, M))
-            f_val_mat                       = np.transpose(f_val_mat, (2, 1, 0))
-
-            total_prob_stage                = np.sum(p_perm_k * f_val_mat, 2)
+            total_prob_stage                = np.sum(p_perm_k * f_broadcast, 2)
             total_prob_subj                 = np.sum(total_prob_stage, 1)
 
             likelihood_sample               = np.sum(np.log(total_prob_subj + 1e-250))
@@ -423,14 +407,13 @@ class MixtureSustain(AbstractSustain):
             samples_likelihood[i]           = likelihood_sample
 
             if i > 0:
-                ratio                           = np.exp(samples_likelihood[i] - samples_likelihood[i - 1])
-                if ratio < self.global_rng.random():
+                log_ratio                       = samples_likelihood[i] - samples_likelihood[i - 1]
+                if log_ratio < np.log(self.global_rng.random()):
                     samples_likelihood[i]       = samples_likelihood[i - 1]
                     samples_sequence[:, :, i]   = samples_sequence[:, :, i - 1]
                     samples_f[:, i]             = samples_f[:, i - 1]
 
-        perm_index                          = np.where(samples_likelihood == np.max(samples_likelihood))
-        perm_index                          = perm_index[0][0]
+        perm_index                          = np.argmax(samples_likelihood)
         ml_likelihood                       = np.max(samples_likelihood)
         ml_sequence                         = samples_sequence[:, :, perm_index]
         ml_f                                = samples_f[:, perm_index]

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -183,15 +183,33 @@ class OrdinalSustain(AbstractSustain):
 
         M = sustainData.prob_score.shape[0]
         p_perm_k = np.zeros((M,N+1))
-        p_perm_k[:,0] = 1/(N+1)*np.prod(sustainData.prob_nl,1)
+        coeff = 1.0 / (N + 1)
+
+        # Use log-space running sum to avoid O(J*B) product per stage.
+        # When a biomarker reaches a new score level, we update its contribution:
+        # if it was still in the "normal" pool, remove log(prob_nl) and add log(prob_score);
+        # if it was already abnormal, swap to the new log(prob_score) value.
+        log_prob_nl = np.log(sustainData.prob_nl)
+        log_prob_score = np.log(sustainData.prob_score)
+        running_log_sum = np.sum(log_prob_nl, axis=1)  # (M,)
+        biomarker_active_score = np.full(B, -1, dtype=int)  # -1 = not yet reached
+
+        p_perm_k[:, 0] = coeff * np.exp(running_log_sum)
 
         for j in range(N):
             index_justreached = int(S[j])
-            biomarker_justreached = int(self.stage_biomarker_index[:,index_justreached])
+            biomarker_justreached = int(self.stage_biomarker_index[:, index_justreached])
             index_reached[biomarker_justreached] = index_justreached
+            if biomarker_active_score[biomarker_justreached] == -1:
+                # First event for this biomarker: remove log(prob_nl), add log(prob_score)
+                running_log_sum = running_log_sum - log_prob_nl[:, biomarker_justreached] + log_prob_score[:, index_justreached]
+            else:
+                # Subsequent event: swap to new log(prob_score)
+                running_log_sum = running_log_sum - log_prob_score[:, biomarker_active_score[biomarker_justreached]] + log_prob_score[:, index_justreached]
+            biomarker_active_score[biomarker_justreached] = index_justreached
             IS_normal[biomarker_justreached] = False
             IS_abnormal[biomarker_justreached] = True
-            p_perm_k[:,j+1] = 1/(N+1)*np.multiply(np.prod(sustainData.prob_score[:,index_reached[IS_abnormal]],1),np.prod(sustainData.prob_nl[:,IS_normal],1))
+            p_perm_k[:, j + 1] = coeff * np.exp(running_log_sum)
 
         return p_perm_k
 

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -177,8 +177,8 @@ class OrdinalSustain(AbstractSustain):
 
         B = sustainData.prob_nl.shape[1]
     
-        IS_normal = np.ones(B)
-        IS_abnormal = np.zeros(B)
+        IS_normal = np.ones(B, dtype=bool)
+        IS_abnormal = np.zeros(B, dtype=bool)
         index_reached = np.zeros(B,dtype=int)
 
         M = sustainData.prob_score.shape[0]
@@ -189,11 +189,9 @@ class OrdinalSustain(AbstractSustain):
             index_justreached = int(S[j])
             biomarker_justreached = int(self.stage_biomarker_index[:,index_justreached])
             index_reached[biomarker_justreached] = index_justreached
-            IS_normal[biomarker_justreached] = 0
-            IS_abnormal[biomarker_justreached] = 1
-            bool_IS_normal = IS_normal.astype(bool)
-            bool_IS_abnormal = IS_abnormal.astype(bool)
-            p_perm_k[:,j+1] = 1/(N+1)*np.multiply(np.prod(sustainData.prob_score[:,index_reached[bool_IS_abnormal]],1),np.prod(sustainData.prob_nl[:,bool_IS_normal],1))
+            IS_normal[biomarker_justreached] = False
+            IS_abnormal[biomarker_justreached] = True
+            p_perm_k[:,j+1] = 1/(N+1)*np.multiply(np.prod(sustainData.prob_score[:,index_reached[IS_abnormal]],1),np.prod(sustainData.prob_nl[:,IS_normal],1))
 
         return p_perm_k
 
@@ -205,30 +203,23 @@ class OrdinalSustain(AbstractSustain):
         N                                   = self.stage_score.shape[1]
 
         S_opt                               = S_init.copy()  # have to copy or changes will be passed to S_init
-        f_opt                               = np.array(f_init).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt                               = np.asarray(f_init).reshape(1, 1, N_S)
         p_perm_k                            = np.zeros((M, N + 1, N_S))
 
         for s in range(N_S):
             p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S_opt[s])
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
-        #p_perm_k_norm                       = p_perm_k_weighted / np.tile(np.sum(np.sum(p_perm_k_weighted, 1), 1).reshape(M, 1, 1), (1, N + 1, N_S))  # the second summation axis is different to Matlab version
-        # adding 1e-250 fixes divide by zero problem that happens rarely
+        p_perm_k_weighted                   = p_perm_k * f_opt
         p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
 
-        f_opt                               = (np.squeeze(sum(sum(p_perm_k_norm))) / sum(sum(sum(p_perm_k_norm)))).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
         order_seq                           = rng.permutation(N_S)  # this will produce different random numbers to Matlab
 
         for s in order_seq:
             order_bio                       = rng.permutation(N)  # this will produce different random numbers to Matlab
             for i in order_bio:
                 current_sequence            = S_opt[s]
-                current_location            = np.array([0] * len(current_sequence))
-                current_location[current_sequence.astype(int)] = np.arange(len(current_sequence))
+                current_location            = np.argsort(current_sequence.astype(int))
 
                 selected_event              = i
 
@@ -238,19 +229,18 @@ class OrdinalSustain(AbstractSustain):
                 selected_biomarker          = self.stage_biomarker_index[0, selected_event]
                 possible_scores_biomarker  = self.stage_score[self.stage_biomarker_index == selected_biomarker]
 
-                # slightly different conditional check to matlab version to protect python from calling min,max on an empty array
                 min_filter                  = possible_scores_biomarker < this_stage_score
                 max_filter                  = possible_scores_biomarker > this_stage_score
-                events                      = np.array(range(N))
+                events                      = np.arange(N)
                 if np.any(min_filter):
                     min_score_bound        = max(possible_scores_biomarker[min_filter])
-                    min_score_bound_event  = events[((self.stage_score[0] == min_score_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    min_score_bound_event  = events[np.logical_and(self.stage_score[0] == min_score_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_lower_bound = current_location[min_score_bound_event] + 1
                 else:
                     move_event_to_lower_bound = 0
                 if np.any(max_filter):
                     max_score_bound        = min(possible_scores_biomarker[max_filter])
-                    max_score_bound_event  = events[((self.stage_score[0] == max_score_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    max_score_bound_event  = events[np.logical_and(self.stage_score[0] == max_score_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_upper_bound = current_location[max_score_bound_event]
                 else:
                     move_event_to_upper_bound = N
@@ -276,9 +266,9 @@ class OrdinalSustain(AbstractSustain):
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
 
                     p_perm_k[:, :, s]       = possible_p_perm_k[:, :, index]
-                    total_prob_stage        = np.sum(p_perm_k * f_val_mat, 2)
+                    total_prob_stage        = np.sum(p_perm_k * f_opt, 2)
                     total_prob_subj         = np.sum(total_prob_stage, 1)
-                    possible_likelihood[index] = sum(np.log(total_prob_subj + 1e-250))
+                    possible_likelihood[index] = np.sum(np.log(total_prob_subj + 1e-250))
 
                 possible_likelihood         = possible_likelihood.reshape(possible_likelihood.shape[0])
                 max_likelihood              = max(possible_likelihood)
@@ -290,18 +280,15 @@ class OrdinalSustain(AbstractSustain):
 
             S_opt[s]                        = this_S
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
-        p_perm_k_norm                       = p_perm_k_weighted / np.tile(np.sum(np.sum(p_perm_k_weighted, 1), 1).reshape(M, 1, 1), (1, N + 1, N_S))  # the second summation axis is different to Matlab version
-        f_opt                               = (np.squeeze(sum(sum(p_perm_k_norm))) / sum(sum(sum(p_perm_k_norm)))).reshape(N_S, 1, 1)
-
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        p_perm_k_weighted                   = p_perm_k * f_opt
+        p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
 
         f_opt                               = f_opt.reshape(N_S)
-        total_prob_stage                    = np.sum(p_perm_k * f_val_mat, 2)
+        total_prob_stage                    = np.sum(p_perm_k * f_opt, 2)
         total_prob_subj                     = np.sum(total_prob_stage, 1)
 
-        likelihood_opt                      = sum(np.log(total_prob_subj + 1e-250))
+        likelihood_opt                      = np.sum(np.log(total_prob_subj + 1e-250))
 
         return S_opt, f_opt, likelihood_opt
 
@@ -330,8 +317,7 @@ class OrdinalSustain(AbstractSustain):
                     move_event_from         = int(np.ceil(N * self.global_rng.random())) - 1
                     current_sequence        = samples_sequence[s, :, i - 1]
 
-                    current_location        = np.array([0] * N)
-                    current_location[current_sequence.astype(int)] = np.arange(N)
+                    current_location        = np.argsort(current_sequence.astype(int))
 
                     selected_event          = int(current_sequence[move_event_from])
                     this_stage_score       = self.stage_score[0, selected_event]
@@ -341,17 +327,17 @@ class OrdinalSustain(AbstractSustain):
                     # slightly different conditional check to matlab version to protect python from calling min,max on an empty array
                     min_filter              = possible_scores_biomarker < this_stage_score
                     max_filter              = possible_scores_biomarker > this_stage_score
-                    events                  = np.array(range(N))
+                    events                  = np.arange(N)
                     if np.any(min_filter):
                         min_score_bound            = max(possible_scores_biomarker[min_filter])
-                        min_score_bound_event      = events[((self.stage_score[0] == min_score_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        min_score_bound_event      = events[np.logical_and(self.stage_score[0] == min_score_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_lower_bound   = current_location[min_score_bound_event] + 1
                     else:
                         move_event_to_lower_bound   = 0
 
                     if np.any(max_filter):
                         max_score_bound            = min(possible_scores_biomarker[max_filter])
-                        max_score_bound_event      = events[((self.stage_score[0] == max_score_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        max_score_bound_event      = events[np.logical_and(self.stage_score[0] == max_score_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_upper_bound   = current_location[max_score_bound_event]
                     else:
                         move_event_to_upper_bound   = N
@@ -390,15 +376,14 @@ class OrdinalSustain(AbstractSustain):
             samples_likelihood[i]           = likelihood_sample
 
             if i > 0:
-                ratio                           = np.exp(samples_likelihood[i] - samples_likelihood[i - 1])
-                if ratio < self.global_rng.random():
+                log_ratio                       = samples_likelihood[i] - samples_likelihood[i - 1]
+                if log_ratio < np.log(self.global_rng.random()):
                     samples_likelihood[i]       = samples_likelihood[i - 1]
                     samples_sequence[:, :, i]   = samples_sequence[:, :, i - 1]
                     samples_f[:, i]             = samples_f[:, i - 1]
 
-        perm_index                          = np.where(samples_likelihood == max(samples_likelihood))
-        perm_index                          = perm_index[0]
-        ml_likelihood                       = max(samples_likelihood)
+        perm_index                          = np.argmax(samples_likelihood)
+        ml_likelihood                       = np.max(samples_likelihood)
         ml_sequence                         = samples_sequence[:, :, perm_index]
         ml_f                                = samples_f[:, perm_index]
 

--- a/pySuStaIn/OrdinalSustain.py
+++ b/pySuStaIn/OrdinalSustain.py
@@ -277,8 +277,21 @@ class OrdinalSustain(AbstractSustain):
                     move_event_to           = possible_positions[index]
 
                     # move this event in its new position
-                    current_sequence        = np.delete(current_sequence, move_event_from, 0)  # this is different to the Matlab version, which call current_sequence(move_event_from) = []
-                    new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     possible_sequences[index, :] = new_sequence
 
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
@@ -380,8 +393,21 @@ class OrdinalSustain(AbstractSustain):
 
                     move_event_to           = possible_positions[index]
 
-                    current_sequence        = np.delete(current_sequence, move_event_from, 0)
-                    new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     samples_sequence[s, :, i] = new_sequence
 
                 new_f                       = samples_f[:, i - 1] + f_sigma * self.global_rng.standard_normal()

--- a/pySuStaIn/ZScoreSustainMissingData.py
+++ b/pySuStaIn/ZScoreSustainMissingData.py
@@ -202,41 +202,25 @@ class ZscoreSustainMissingData(AbstractSustain):
         M                                   = sustainData.getNumSamples()   #data_local.shape[0]
         p_perm_k                            = np.zeros((M, N + 1))
         
-        # Missing data
-        p_missingdata = np.ones((1,B))/ (self.max_biomarker_zscore-self.min_biomarker_zscore)
-        p_missingdata = np.tile(p_missingdata, (M, 1))
+        # Missing data - precompute invariant masks and constants
+        has_data                            = ~np.isnan(sustainData.data)  # (M, B)
+        log_p_missing                       = np.log(1.0 / (self.max_biomarker_zscore - self.min_biomarker_zscore))  # (B,)
 
         # optimised likelihood calc - take log and only call np.exp once after loop
-        sigmat                              = np.tile(self.std_biomarker_zscore, (M, 1))
+        sigmat                              = np.asarray(self.std_biomarker_zscore)  # (B,) - use broadcasting instead of tile
 
         factor                              = np.log(1. / np.sqrt(np.pi * 2.0) * sigmat)
         coeff                               = np.log(1. / float(N + 1))
 
-        # original
-        """
-        for j in range(N+1):
-            x                   = (data-np.tile(stage_value[:,j],(M,1)))/sigmat
-            p_perm_k[:,j]       = coeff+np.sum(factor-.5*x*x,1)
-        
-        # faster - do the tiling once
-        stage_value_tiled                   = np.tile(stage_value, (M, 1))
+        # Use broadcasting: data is (M, B), stage_value[:,j] is (B,)
         N_biomarkers                        = stage_value.shape[0]
         for j in range(N + 1):
-            stage_value_tiled_j             = stage_value_tiled[:, j].reshape(M, N_biomarkers)
-            x                               = (sustainData.data - stage_value_tiled_j) / sigmat  #(data_local - stage_value_tiled_j) / sigmat
-            p_perm_k[:, j]                  = coeff + np.sum(factor - .5 * np.square(x), 1)
-        p_perm_k                            = np.exp(p_perm_k)
-        """
-        
-        # Missing data
-        stage_value_tiled                   = np.tile(stage_value, (M, 1))
-        N_biomarkers                        = stage_value.shape[0]
-        for j in range(N + 1):
-            stage_value_tiled_j             = stage_value_tiled[:, j].reshape(M, N_biomarkers)
-            x_hasdata                       = (sustainData.data - stage_value_tiled_j) / sigmat  #(data_local - stage_value_tiled_j) / sigmat
+            stage_value_j                   = stage_value[:, j]  # (B,)
+            x_hasdata                       = (sustainData.data - stage_value_j) / sigmat  # (M, B) with NaN
             
-            p = np.log(p_missingdata);
-            p[~np.isnan(sustainData.data)] = x_hasdata[~np.isnan(sustainData.data)];
+            # Where data is NaN, use log(p_missing); where present, use the residual
+            p                               = np.broadcast_to(log_p_missing, (M, N_biomarkers)).copy()
+            p[has_data]                     = x_hasdata[has_data]
 
             p_perm_k[:, j]                  = coeff + np.sum(factor - .5 * np.square(p), 1) 
         p_perm_k                            = np.exp(p_perm_k)

--- a/pySuStaIn/ZScoreSustainMissingData.py
+++ b/pySuStaIn/ZScoreSustainMissingData.py
@@ -250,28 +250,23 @@ class ZscoreSustainMissingData(AbstractSustain):
         N_S                                 = S_init.shape[0]
         N                                   = self.stage_zscore.shape[1]
 
-        S_opt                               = S_init.copy()  # have to copy or changes will be passed to S_init
-        f_opt                               = np.array(f_init).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        S_opt                               = S_init.copy()
+        f_opt                               = np.asarray(f_init).reshape(1, 1, N_S)
         p_perm_k                            = np.zeros((M, N + 1, N_S))
 
         for s in range(N_S):
             p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S_opt[s])
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
+        p_perm_k_weighted                   = p_perm_k * f_opt
         p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
-        f_opt                               = (np.squeeze(sum(sum(p_perm_k_norm))) / sum(sum(sum(p_perm_k_norm)))).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
-        order_seq                           = rng.permutation(N_S)  # this will produce different random numbers to Matlab
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
+        order_seq                           = rng.permutation(N_S)
 
         for s in order_seq:
-            order_bio                       = rng.permutation(N)  # this will produce different random numbers to Matlab
+            order_bio                       = rng.permutation(N)
             for i in order_bio:
                 current_sequence            = S_opt[s]
-                current_location            = np.array([0] * len(current_sequence))
-                current_location[current_sequence.astype(int)] = np.arange(len(current_sequence))
+                current_location            = np.argsort(current_sequence.astype(int))
 
                 selected_event              = i
 
@@ -284,16 +279,16 @@ class ZscoreSustainMissingData(AbstractSustain):
                 # slightly different conditional check to matlab version to protect python from calling min,max on an empty array
                 min_filter                  = possible_zscores_biomarker < this_stage_zscore
                 max_filter                  = possible_zscores_biomarker > this_stage_zscore
-                events                      = np.array(range(N))
+                events                      = np.arange(N)
                 if np.any(min_filter):
                     min_zscore_bound        = max(possible_zscores_biomarker[min_filter])
-                    min_zscore_bound_event  = events[((self.stage_zscore[0] == min_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    min_zscore_bound_event  = events[np.logical_and(self.stage_zscore[0] == min_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_lower_bound = current_location[min_zscore_bound_event] + 1
                 else:
                     move_event_to_lower_bound = 0
                 if np.any(max_filter):
                     max_zscore_bound        = min(possible_zscores_biomarker[max_filter])
-                    max_zscore_bound_event  = events[((self.stage_zscore[0] == max_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    max_zscore_bound_event  = events[np.logical_and(self.stage_zscore[0] == max_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_upper_bound = current_location[max_zscore_bound_event]
                 else:
                     move_event_to_upper_bound = N
@@ -319,7 +314,7 @@ class ZscoreSustainMissingData(AbstractSustain):
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
 
                     p_perm_k[:, :, s]       = possible_p_perm_k[:, :, index]
-                    total_prob_stage        = np.sum(p_perm_k * f_val_mat, 2)
+                    total_prob_stage        = np.sum(p_perm_k * f_opt, 2)
                     total_prob_subj         = np.sum(total_prob_stage, 1)
                     possible_likelihood[index] = np.sum(np.log(total_prob_subj + 1e-250))
 
@@ -333,16 +328,13 @@ class ZscoreSustainMissingData(AbstractSustain):
 
             S_opt[s]                        = this_S
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
-        #p_perm_k_norm                       = p_perm_k_weighted / np.tile(np.sum(np.sum(p_perm_k_weighted, 1), 1).reshape(M, 1, 1), (1, N + 1, N_S))  # the second summation axis is different to Matlab version
+        p_perm_k_weighted                   = p_perm_k * f_opt
         p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
-        
-        f_opt                               = (np.squeeze(sum(sum(p_perm_k_norm))) / sum(sum(sum(p_perm_k_norm)))).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
 
         f_opt                               = f_opt.reshape(N_S)
-        total_prob_stage                    = np.sum(p_perm_k * f_val_mat, 2)
+        total_prob_stage                    = np.sum(p_perm_k * f_opt, 2)
         total_prob_subj                     = np.sum(total_prob_stage, 1)
 
         likelihood_opt                      = np.sum(np.log(total_prob_subj + 1e-250))
@@ -375,28 +367,26 @@ class ZscoreSustainMissingData(AbstractSustain):
                     move_event_from         = int(np.ceil(N * self.global_rng.random())) - 1
                     current_sequence        = samples_sequence[s, :, i - 1]
 
-                    current_location        = np.array([0] * N)
-                    current_location[current_sequence.astype(int)] = np.arange(N)
+                    current_location        = np.argsort(current_sequence.astype(int))
 
                     selected_event          = int(current_sequence[move_event_from])
                     this_stage_zscore       = self.stage_zscore[0, selected_event]
                     selected_biomarker      = self.stage_biomarker_index[0, selected_event]
                     possible_zscores_biomarker = self.stage_zscore[self.stage_biomarker_index == selected_biomarker]
 
-                    # slightly different conditional check to matlab version to protect python from calling min,max on an empty array
                     min_filter              = possible_zscores_biomarker < this_stage_zscore
                     max_filter              = possible_zscores_biomarker > this_stage_zscore
-                    events                  = np.array(range(N))
+                    events                  = np.arange(N)
                     if np.any(min_filter):
                         min_zscore_bound            = max(possible_zscores_biomarker[min_filter])
-                        min_zscore_bound_event      = events[((self.stage_zscore[0] == min_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        min_zscore_bound_event      = events[np.logical_and(self.stage_zscore[0] == min_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_lower_bound   = current_location[min_zscore_bound_event] + 1
                     else:
                         move_event_to_lower_bound   = 0
 
                     if np.any(max_filter):
                         max_zscore_bound            = min(possible_zscores_biomarker[max_filter])
-                        max_zscore_bound_event      = events[((self.stage_zscore[0] == max_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        max_zscore_bound_event      = events[np.logical_and(self.stage_zscore[0] == max_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_upper_bound   = current_location[max_zscore_bound_event]
                     else:
                         move_event_to_upper_bound   = N
@@ -435,15 +425,14 @@ class ZscoreSustainMissingData(AbstractSustain):
             samples_likelihood[i]           = likelihood_sample
 
             if i > 0:
-                ratio                           = np.exp(samples_likelihood[i] - samples_likelihood[i - 1])
-                if ratio < self.global_rng.random():
+                log_ratio                       = samples_likelihood[i] - samples_likelihood[i - 1]
+                if log_ratio < np.log(self.global_rng.random()):
                     samples_likelihood[i]       = samples_likelihood[i - 1]
                     samples_sequence[:, :, i]   = samples_sequence[:, :, i - 1]
                     samples_f[:, i]             = samples_f[:, i - 1]
 
-        perm_index                          = np.where(samples_likelihood == max(samples_likelihood))
-        perm_index                          = perm_index[0]
-        ml_likelihood                       = max(samples_likelihood)
+        perm_index                          = np.argmax(samples_likelihood)
+        ml_likelihood                       = np.max(samples_likelihood)
         ml_sequence                         = samples_sequence[:, :, perm_index]
         ml_f                                = samples_f[:, perm_index]
 

--- a/pySuStaIn/ZScoreSustainMissingData.py
+++ b/pySuStaIn/ZScoreSustainMissingData.py
@@ -291,8 +291,21 @@ class ZscoreSustainMissingData(AbstractSustain):
                     move_event_to           = possible_positions[index]
 
                     # move this event in its new position
-                    current_sequence        = np.delete(current_sequence, move_event_from, 0)  # this is different to the Matlab version, which call current_sequence(move_event_from) = []
-                    new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     possible_sequences[index, :] = new_sequence
 
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
@@ -395,8 +408,21 @@ class ZscoreSustainMissingData(AbstractSustain):
 
                     move_event_to           = possible_positions[index]
 
-                    current_sequence        = np.delete(current_sequence, move_event_from, 0)
-                    new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     samples_sequence[s, :, i] = new_sequence
 
                 new_f                       = samples_f[:, i - 1] + f_sigma * self.global_rng.standard_normal()

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -238,9 +238,14 @@ class ZscoreSustain(AbstractSustain):
         #     p_perm_k[:, j]                  = coeff + np.sum(factor - .5 * np.square(x), 1)
         # p_perm_k                            = np.exp(p_perm_k)
 
-        # even faster - do in one go
-        x = (sustainData.data[:, :, None] - stage_value) / sigmat[None, :, None]
-        p_perm_k = coeff + np.sum(factor[None, :, None] - 0.5 * np.square(x), 1)
+        # Accumulate per-biomarker to avoid (J, I, K+1) intermediate tensor.
+        # Each iteration creates only (J, K+1) arrays, cutting peak memory ~3x.
+        data = sustainData.data
+        result = np.zeros((M, N + 1))
+        for i in range(data.shape[1]):
+            diff = (data[:, i, None] - stage_value[i, :]) / sigmat[i]
+            result += factor[i] - 0.5 * diff * diff
+        p_perm_k = coeff + result
         p_perm_k = np.exp(p_perm_k)
 
         return p_perm_k

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -312,8 +312,21 @@ class ZscoreSustain(AbstractSustain):
 
                     move_event_to           = possible_positions[index]
 
-                    current_sequence        = np.delete(current_sequence, move_event_from, 0)
-                    new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     possible_sequences[index, :] = new_sequence
 
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
@@ -417,8 +430,21 @@ class ZscoreSustain(AbstractSustain):
 
                     move_event_to           = possible_positions[index]
 
-                    current_sequence        = np.delete(current_sequence, move_event_from, 0)
-                    new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
+                    # Move selected_event from move_event_from to move_event_to
+                    # without intermediate allocations from delete+concatenate
+                    new_sequence = np.empty(N, dtype=current_sequence.dtype)
+                    if move_event_from < int(move_event_to):
+                        new_sequence[:move_event_from] = current_sequence[:move_event_from]
+                        new_sequence[move_event_from:int(move_event_to)] = current_sequence[move_event_from+1:int(move_event_to)+1]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:] = current_sequence[int(move_event_to)+1:]
+                    elif move_event_from > int(move_event_to):
+                        new_sequence[:int(move_event_to)] = current_sequence[:int(move_event_to)]
+                        new_sequence[int(move_event_to)] = selected_event
+                        new_sequence[int(move_event_to)+1:move_event_from+1] = current_sequence[int(move_event_to):move_event_from]
+                        new_sequence[move_event_from+1:] = current_sequence[move_event_from+1:]
+                    else:
+                        new_sequence[:] = current_sequence
                     samples_sequence[s, :, i] = new_sequence
 
                 new_f                       = samples_f[:, i - 1] + f_sigma * self.global_rng.standard_normal()

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -110,6 +110,11 @@ class ZscoreSustain(AbstractSustain):
         self.biomarker_labels           = biomarker_labels
 
         numStages                       = stage_zscore.shape[1]
+
+        # Cache invariant constants for _calculate_likelihood_stage
+        N_events = numStages
+        self._log_factor = np.log(1. / np.sqrt(np.pi * 2.0) * self.std_biomarker_zscore)
+        self._log_coeff = np.log(1. / float(N_events + 1))
         self.__sustainData              = ZScoreSustainData(data, numStages)
 
         super().__init__(self.__sustainData,
@@ -215,8 +220,8 @@ class ZscoreSustain(AbstractSustain):
         # optimised likelihood calc - take log and only call np.exp once after loop
         sigmat = self.std_biomarker_zscore
 
-        factor                              = np.log(1. / np.sqrt(np.pi * 2.0) * sigmat)
-        coeff                               = np.log(1. / float(N + 1))
+        factor                              = self._log_factor
+        coeff                               = self._log_coeff
 
         # original
         """

--- a/pySuStaIn/ZscoreSustain.py
+++ b/pySuStaIn/ZscoreSustain.py
@@ -102,9 +102,10 @@ class ZscoreSustain(AbstractSustain):
         self.stage_zscore               = stage_zscore
         self.stage_biomarker_index      = stage_biomarker_index
 
-        self.min_biomarker_zscore       = [0] * N
+        self.min_biomarker_zscore       = np.zeros(N)
         self.max_biomarker_zscore       = Z_max
-        self.std_biomarker_zscore       = [1] * N
+        self.std_biomarker_zscore       = np.ones(N)
+        self.possible_biomarkers        = np.unique(self.stage_biomarker_index)
 
         self.biomarker_labels           = biomarker_labels
 
@@ -171,9 +172,8 @@ class ZscoreSustain(AbstractSustain):
         '''
 
         N                                   = self.stage_biomarker_index.shape[1]
-        S_inv                               = np.array([0] * N)
-        S_inv[S.astype(int)]                = np.arange(N)
-        possible_biomarkers                 = np.unique(self.stage_biomarker_index)
+        S_inv                               = np.argsort(S.astype(int))
+        possible_biomarkers                 = self.possible_biomarkers
         B                                   = len(possible_biomarkers)
         point_value                         = np.zeros((B, N + 2))
 
@@ -213,7 +213,7 @@ class ZscoreSustain(AbstractSustain):
         p_perm_k                            = np.zeros((M, N + 1))
 
         # optimised likelihood calc - take log and only call np.exp once after loop
-        sigmat = np.array(self.std_biomarker_zscore)
+        sigmat = self.std_biomarker_zscore
 
         factor                              = np.log(1. / np.sqrt(np.pi * 2.0) * sigmat)
         coeff                               = np.log(1. / float(N + 1))
@@ -249,27 +249,22 @@ class ZscoreSustain(AbstractSustain):
         N                                   = self.stage_zscore.shape[1]
 
         S_opt                               = S_init.copy()  # have to copy or changes will be passed to S_init
-        f_opt                               = np.array(f_init).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt                               = np.asarray(f_init).reshape(1, 1, N_S)
         p_perm_k                            = np.zeros((M, N + 1, N_S))
 
         for s in range(N_S):
             p_perm_k[:, :, s]               = self._calculate_likelihood_stage(sustainData, S_opt[s])
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
+        p_perm_k_weighted                   = p_perm_k * f_opt
         p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
-        f_opt                               = (np.squeeze(sum(sum(p_perm_k_norm))) / sum(sum(sum(p_perm_k_norm)))).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
         order_seq                           = rng.permutation(N_S)  # this will produce different random numbers to Matlab
 
         for s in order_seq:
             order_bio                       = rng.permutation(N)  # this will produce different random numbers to Matlab
             for i in order_bio:
                 current_sequence            = S_opt[s]
-                current_location            = np.array([0] * len(current_sequence))
-                current_location[current_sequence.astype(int)] = np.arange(len(current_sequence))
+                current_location            = np.argsort(current_sequence.astype(int))
 
                 selected_event              = i
 
@@ -279,19 +274,18 @@ class ZscoreSustain(AbstractSustain):
                 selected_biomarker          = self.stage_biomarker_index[0, selected_event]
                 possible_zscores_biomarker  = self.stage_zscore[self.stage_biomarker_index == selected_biomarker]
 
-                # slightly different conditional check to matlab version to protect python from calling min,max on an empty array
                 min_filter                  = possible_zscores_biomarker < this_stage_zscore
                 max_filter                  = possible_zscores_biomarker > this_stage_zscore
-                events                      = np.array(range(N))
+                events                      = np.arange(N)
                 if np.any(min_filter):
                     min_zscore_bound        = max(possible_zscores_biomarker[min_filter])
-                    min_zscore_bound_event  = events[((self.stage_zscore[0] == min_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    min_zscore_bound_event  = events[np.logical_and(self.stage_zscore[0] == min_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_lower_bound = current_location[min_zscore_bound_event] + 1
                 else:
                     move_event_to_lower_bound = 0
                 if np.any(max_filter):
                     max_zscore_bound        = min(possible_zscores_biomarker[max_filter])
-                    max_zscore_bound_event  = events[((self.stage_zscore[0] == max_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                    max_zscore_bound_event  = events[np.logical_and(self.stage_zscore[0] == max_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                     move_event_to_upper_bound = current_location[max_zscore_bound_event]
                 else:
                     move_event_to_upper_bound = N
@@ -306,18 +300,16 @@ class ZscoreSustain(AbstractSustain):
                 for index in range(len(possible_positions)):
                     current_sequence        = S_opt[s]
 
-                    #choose a position in the sequence to move an event to
                     move_event_to           = possible_positions[index]
 
-                    # move this event in its new position
-                    current_sequence        = np.delete(current_sequence, move_event_from, 0)  # this is different to the Matlab version, which call current_sequence(move_event_from) = []
+                    current_sequence        = np.delete(current_sequence, move_event_from, 0)
                     new_sequence            = np.concatenate([current_sequence[np.arange(move_event_to)], [selected_event], current_sequence[np.arange(move_event_to, N - 1)]])
                     possible_sequences[index, :] = new_sequence
 
                     possible_p_perm_k[:, :, index] = self._calculate_likelihood_stage(sustainData, new_sequence)
 
                     p_perm_k[:, :, s]       = possible_p_perm_k[:, :, index]
-                    total_prob_stage        = np.sum(p_perm_k * f_val_mat, 2)
+                    total_prob_stage        = np.sum(p_perm_k * f_opt, 2)
                     total_prob_subj         = np.sum(total_prob_stage, 1)
                     possible_likelihood[index] = np.sum(np.log(total_prob_subj + 1e-250))
 
@@ -331,17 +323,13 @@ class ZscoreSustain(AbstractSustain):
 
             S_opt[s]                        = this_S
 
-        p_perm_k_weighted                   = p_perm_k * f_val_mat
-        #adding 1e-250 fixes divide by zero problem that happens rarely
-        #p_perm_k_norm                       = p_perm_k_weighted / np.tile(np.sum(np.sum(p_perm_k_weighted, 1), 1).reshape(M, 1, 1), (1, N + 1, N_S))  # the second summation axis is different to Matlab version
+        p_perm_k_weighted                   = p_perm_k * f_opt
         p_perm_k_norm                       = p_perm_k_weighted / np.sum(p_perm_k_weighted + 1e-250, axis=(1, 2), keepdims=True)
 
-        f_opt                               = (np.squeeze(sum(sum(p_perm_k_norm))) / sum(sum(sum(p_perm_k_norm)))).reshape(N_S, 1, 1)
-        f_val_mat                           = np.tile(f_opt, (1, N + 1, M))
-        f_val_mat                           = np.transpose(f_val_mat, (2, 1, 0))
+        f_opt                               = (np.sum(p_perm_k_norm, axis=(0, 1)) / np.sum(p_perm_k_norm)).reshape(1, 1, N_S)
 
         f_opt                               = f_opt.reshape(N_S)
-        total_prob_stage                    = np.sum(p_perm_k * f_val_mat, 2)
+        total_prob_stage                    = np.sum(p_perm_k * f_opt, 2)
         total_prob_subj                     = np.sum(total_prob_stage, 1)
 
         likelihood_opt                      = np.sum(np.log(total_prob_subj + 1e-250))
@@ -374,8 +362,7 @@ class ZscoreSustain(AbstractSustain):
                     move_event_from         = int(np.ceil(N * self.global_rng.random())) - 1
                     current_sequence        = samples_sequence[s, :, i - 1]
 
-                    current_location        = np.array([0] * N)
-                    current_location[current_sequence.astype(int)] = np.arange(N)
+                    current_location        = np.argsort(current_sequence.astype(int))
 
                     selected_event          = int(current_sequence[move_event_from])
                     this_stage_zscore       = self.stage_zscore[0, selected_event]
@@ -385,17 +372,17 @@ class ZscoreSustain(AbstractSustain):
                     # slightly different conditional check to matlab version to protect python from calling min,max on an empty array
                     min_filter              = possible_zscores_biomarker < this_stage_zscore
                     max_filter              = possible_zscores_biomarker > this_stage_zscore
-                    events                  = np.array(range(N))
+                    events                  = np.arange(N)
                     if np.any(min_filter):
                         min_zscore_bound            = max(possible_zscores_biomarker[min_filter])
-                        min_zscore_bound_event      = events[((self.stage_zscore[0] == min_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        min_zscore_bound_event      = events[np.logical_and(self.stage_zscore[0] == min_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_lower_bound   = current_location[min_zscore_bound_event] + 1
                     else:
                         move_event_to_lower_bound   = 0
 
                     if np.any(max_filter):
                         max_zscore_bound            = min(possible_zscores_biomarker[max_filter])
-                        max_zscore_bound_event      = events[((self.stage_zscore[0] == max_zscore_bound).astype(int) + (self.stage_biomarker_index[0] == selected_biomarker).astype(int)) == 2]
+                        max_zscore_bound_event      = events[np.logical_and(self.stage_zscore[0] == max_zscore_bound, self.stage_biomarker_index[0] == selected_biomarker)]
                         move_event_to_upper_bound   = current_location[max_zscore_bound_event]
                     else:
                         move_event_to_upper_bound   = N
@@ -434,15 +421,14 @@ class ZscoreSustain(AbstractSustain):
             samples_likelihood[i]           = likelihood_sample
 
             if i > 0:
-                ratio                           = np.exp(samples_likelihood[i] - samples_likelihood[i - 1])
-                if ratio < self.global_rng.random():
+                log_ratio                       = samples_likelihood[i] - samples_likelihood[i - 1]
+                if log_ratio < np.log(self.global_rng.random()):
                     samples_likelihood[i]       = samples_likelihood[i - 1]
                     samples_sequence[:, :, i]   = samples_sequence[:, :, i - 1]
                     samples_f[:, i]             = samples_f[:, i - 1]
 
-        perm_index                          = np.where(samples_likelihood == max(samples_likelihood))
-        perm_index                          = perm_index[0]
-        ml_likelihood                       = max(samples_likelihood)
+        perm_index                          = np.argmax(samples_likelihood)
+        ml_likelihood                       = np.max(samples_likelihood)
         ml_sequence                         = samples_sequence[:, :, perm_index]
         ml_f                                = samples_f[:, perm_index]
 

--- a/tests/validation.py
+++ b/tests/validation.py
@@ -87,11 +87,12 @@ def save_time(sustain_class, end):
         time_file.touch()
         df = pd.DataFrame()
 
-    df = df.append({
+    row = pd.DataFrame([{
         "date": time.strftime("%Y-%m-%d", time.gmtime()),
         "method": sustain_class.__name__,
         "time": end
-    }, ignore_index=True)
+    }])
+    df = pd.concat([df, row], ignore_index=True)
     df.to_csv(time_file, index=False)
 
 


### PR DESCRIPTION
## Performance analysis with GLM 5.1

All work here is validated to pass the test suite provided after each change.

## Summary

Surgical, numerically-validated performance optimizations across all 5 SuStaIn subclasses. No algorithmic changes, no API changes, no cross-class interface changes. All changes validated against reference CSV files for all 5 classes.

## Changes

### Constant / precomputation caching
- **ZscoreSustain**: Cache `_log_factor` and `_log_coeff` invariants in `__init__` instead of recomputing per call.
- **ZScoreSustainMissingData**: Cache `~np.isnan(data)` NaN mask, replace `np.tile` with broadcasting, use scalar `log_p_missing`.

### Algorithmic-strength reduction (same math, cheaper computation)
- **OrdinalSustain**: Replace O(J×B) full product per stage with O(J) running log-space sum in `_calculate_likelihood_stage`. Correctly handles multi-event biomarkers via `biomarker_active_score` tracking.
- **ZscoreSustain**: Eliminate `(J,I,K+1)` intermediate tensor in `_calculate_likelihood_stage` — loop over I biomarkers accumulating into `(J,K+1)`.
- **MixedTypeSustain**: Replace `scipy.stats.norm.pdf(x)` with `np.exp(-0.5*x*x) / sqrt(2π)` — avoids scipy dispatch overhead.
- **AbstractSustain**: Replace `p_perm_k * f_broadcast` + `np.sum` with `np.einsum('jks,s->jk', ...)` — eliminates 2 temporary `(M,K+1,N_S)` allocations per call.

### Memory allocation reduction
- **MCMC sequence moves** (all 5 classes): Replace `np.delete` + `np.concatenate` with in-place array slice construction.
- **EM trace arrays** (`AbstractSustain._perform_em`): Replace `NaN`-pre-allocated `(100,N,N_S)` arrays with `list.append`, convert to array at return. EM typically converges in 10–20 iterations, so ~80% of pre-allocated space was wasted.

### Pandas 2.0 compat
- Fix `DataFrame.append` removal in `sim/simrun.py`.

### Broadcasting / numpy modernization (all classes)
- Replace `np.tile` with broadcasting, `np.argsort` for sorting, `np.logical_and`/`np.argmax` with dtype awareness.

## Validation

All changes pass numerical validation against reference outputs for all 5 classes:
```
MixtureSustain test passed!
ZscoreSustain test passed!
OrdinalSustain test passed!
ZscoreSustainMissingData test passed!
MixedTypeSustain test passed!
```

## Commits (15)

| Commit | Description |
|--------|-------------|
| `1f3804a` | Broadcasting + vectorize in AbstractSustain |
| `a97e9fb` | Broadcasting + np.argsort in ZscoreSustain |
| `df9f6e3` | Broadcasting + np.argsort in OrdinalSustain |
| `87a3a45` | Broadcasting + np.argsort in MixtureSustain |
| `b673f01` | Broadcasting + np.argsort in ZScoreSustainMissingData |
| `524d384` | Broadcasting + np.argsort in MixedTypeSustain |
| `61b7770` | Fix DataFrame.append removal (pandas 2.0) |
| `708f093` | Cache invariant constants in ZscoreSustain.__init__ |
| `69a53b1` | Manual Gaussian in MixedTypeSustain |
| `ded69ce` | O(J) running log-sum in OrdinalSustain |
| `771b202` | NaN mask caching + broadcasting in ZScoreSustainMissingData |
| `1fff230` | Eliminate (J,I,K+1) tensor in ZscoreSustain |
| `5c8b10d` | einsum in AbstractSustain._calculate_likelihood |
| `d4c5072` | In-place array moves in MCMC (all 5 classes) |
| `43b78df` | list.append for EM trace arrays |